### PR TITLE
Reynir-->Greynir in all code headers + documentation/comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ scoring heuristics to find the best parse trees. The trees are then stored in a
 database and processed by grammatical pattern matching modules to obtain statements
 of fact and relations between stated facts.
 
-<a href="https://raw.githubusercontent.com/mideind/Reynir/master/static/img/tree-example.png" title="Greynir parse tree">
+<a href="https://raw.githubusercontent.com/mideind/Greynir/master/static/img/tree-example.png" title="Greynir parse tree">
 <img src="static/img/tree-example-small.png" width="400" height="450" alt="Greynir parse tree">
 </a>
 

--- a/article.py
+++ b/article.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Article class
 
@@ -49,7 +49,7 @@ MAX_SENTENCE_TOKENS = 100
 class Article:
 
     """ An Article represents a new article typically scraped from a web site,
-        as it is tokenized, parsed and stored in the Reynir database. """
+        as it is tokenized, parsed and stored in the Greynir database. """
 
     _parser = None
 

--- a/config/Reynir.conf
+++ b/config/Reynir.conf
@@ -1,7 +1,7 @@
 #
 # Reynir.conf
 #
-# Configuration file for Reynir
+# Configuration file for Greynir
 #
 # Copyright (C) 2018 Miðeind ehf
 #

--- a/config/ReynirSimple.conf
+++ b/config/ReynirSimple.conf
@@ -1,7 +1,7 @@
 #
 # ReynirSimple.conf
 #
-# Configuration file for Reynir - simple version
+# Configuration file for Greynir - simple version
 # (only loads the basic web and database configuration;
 # skips the lexicon configuration)
 #

--- a/config/Vocab.conf
+++ b/config/Vocab.conf
@@ -1,5 +1,5 @@
 #
-# Reynir: Natural language processing for Icelandic
+# Greynir: Natural language processing for Icelandic
 #
 # Vocab.conf
 #

--- a/config/greynir.is.conf
+++ b/config/greynir.is.conf
@@ -2,7 +2,7 @@
 #
 # greynir.is nginx proxy configuration file
 #
-# nginx is a proxy in front of Gunicorn, which runs the main Reynir server
+# nginx is a proxy in front of Gunicorn, which runs the main Greynir server
 #
 
 # See https://github.com/benoitc/gunicorn/blob/master/examples/nginx.conf

--- a/correct.py
+++ b/correct.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     High-level wrappers for checking grammar and spelling
 

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Scraper database model
 

--- a/db/models.py
+++ b/db/models.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Scraper database models
 

--- a/db/queries.py
+++ b/db/queries.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Scraper database queries
 

--- a/db/setup.py
+++ b/db/setup.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Scraper database initialization module
 

--- a/doc.py
+++ b/doc.py
@@ -1,5 +1,5 @@
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (c) 2019 Miðeind ehf.
 

--- a/docs/setup_linux.md
+++ b/docs/setup_linux.md
@@ -63,8 +63,8 @@ Check out the Greynir repo:
 
 ```
 cd ~
-git clone https://github.com/mideind/Reynir
-cd ~/Reynir
+git clone https://github.com/mideind/Greynir
+cd ~/Greynir
 ```
 
 Create and activate virtual environment, install required Python packages:
@@ -151,16 +151,16 @@ Finally, create the database tables used by Greynir (this will only create
 the tables if needed, and no existing data is erased):
 
 ```
-cd ~/Reynir
+cd ~/Greynir
 python scraper.py --init
 ```
 
 ## Run
 
-Change to the Reynir repository and activate the virtual environment:
+Change to the Greynir repository and activate the virtual environment:
 
 ```
-cd ~/Reynir
+cd ~/Greynir
 source venv/bin/activate
 ```
 
@@ -188,5 +188,5 @@ python scraper.py
 ```
 
 Starts an [IPython](https://ipython.org) shell with a database session (`s`), 
-the Reynir parser (`r`) and all SQLAlchemy database models preloaded. For more 
+the Greynir parser (`r`) and all SQLAlchemy database models preloaded. For more 
 info, see [Using the Greynir Shell](shell.md).

--- a/docs/setup_macos.md
+++ b/docs/setup_macos.md
@@ -30,8 +30,8 @@ Check out source code using [git](https://git-scm.com):
 
 ```
 cd ~
-git clone https://github.com/mideind/Reynir
-cd ~/Reynir
+git clone https://github.com/mideind/Greynir
+cd ~/Greynir
 ```
 
 Create and activate virtual environment, install required Python packages:
@@ -84,16 +84,16 @@ Finally, create the database tables used by Greynir (this will only create
 the tables if needed, and no existing data is erased):
 
 ```
-cd ~/Reynir
+cd ~/Greynir
 python scraper.py --init
 ```
 
 ## Run
 
-Change to the Reynir repo directory and activate the virtual environment:
+Change to the Greynir repo directory and activate the virtual environment:
 
 ```
-cd ~/Reynir
+cd ~/Greynir
 source venv/bin/activate
 ```
 
@@ -126,5 +126,5 @@ export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 ```
 
 Starts an [IPython](https://ipython.org) shell with a database session (`s`), 
-the Reynir parser (`r`) and all SQLAlchemy database models preloaded. For 
+the Greynir parser (`r`) and all SQLAlchemy database models preloaded. For 
 more info, see [Using the Greynir Shell](shell.md).

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -20,10 +20,10 @@ To enable auto-reloading of modules prior to every command, run the following co
 %autoreload 2
 ```
 
-The shell has been configured to automatically import Greynir's database models and create a (commit-disabled) database session when launched. The Reynir parser is also imported.
+The shell has been configured to automatically import Greynir's database models and create a (commit-disabled) database session when launched. The Greynir parser is also imported.
 
 * `s` - SQLAlchemy database session
-* `r` - Instance of the [Reynir](https://github.com/mideind/ReynirPackage) parser.
+* `r` - Instance of the [Greynir](https://github.com/mideind/ReynirPackage) parser.
 
 For an overview of Greynir's database models, see `db/models.py`.
 
@@ -57,7 +57,7 @@ Out[6]:
  ('Ingólfur Helgason', 'fyrrverandi forstjóri Kaupþings á Íslandi')]
 ```
 
-### Parsing with Reynir
+### Parsing with Greynir
 
 ```
 In [1]: sent = r.parse_single("Mikið væri það skemmtilegt fyrir Gunna.")

--- a/fetcher.py
+++ b/fetcher.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Fetcher module
 

--- a/geo.py
+++ b/geo.py
@@ -1,5 +1,5 @@
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (c) 2018 Miðeind ehf.
 

--- a/images.py
+++ b/images.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Image retrieval module
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Web server main module
 
@@ -289,7 +289,7 @@ else:
 
     # Log our startup
     log_str = (
-        "Reynir instance starting with "
+        "Greynir instance starting with "
         "host={0}:{1}, db_host={2}:{3} on Python {4}".format(
             Settings.HOST,
             Settings.PORT,

--- a/nertokenizer.py
+++ b/nertokenizer.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     High-level tokenizer and named entity recognizer
 

--- a/postagger.py
+++ b/postagger.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     POS tagger module
 
@@ -19,7 +19,7 @@
     along with this program.  If not, see http://www.gnu.org/licenses/.
 
 
-    This module implements a wrapper for Reynir's POS tagging
+    This module implements a wrapper for Greynir's POS tagging
     functionality. It allows clients to simply and cleanly generate POS tags
     from plain text into a Python dict, which can then easily be converted to
     JSON if desired.
@@ -191,7 +191,7 @@ class NgramTagger:
         tokenizer. A parse tree is not required, so the class can
         also tag sentences for which there is no parse. The tagging
         is based on n-gram and lemma statistics harvested from
-        the Reynir article database. """
+        the Greynir article database. """
 
     CASE_TO_TAG = {
         "þf" : "ao",

--- a/processor.py
+++ b/processor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Processor module
 
@@ -333,7 +333,7 @@ def process_articles(
     num_workers=None,
 ):
     """ Process multiple articles according to the given parameters """
-    print("------ Reynir starting processing -------")
+    print("------ Greynir starting processing -------")
     if from_date:
         print("From date: {0}".format(from_date))
     if limit:
@@ -400,7 +400,7 @@ def init_db():
 
 __doc__ = """
 
-    Reynir - Natural language processing for Icelandic
+    Greynir - Natural language processing for Icelandic
 
     Processor module
 

--- a/processors/__init__.py
+++ b/processors/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Processors folder
 

--- a/processors/attribs.py
+++ b/processors/attribs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Processor module to extract attributes of objects
 

--- a/processors/entities.py
+++ b/processors/entities.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Processor module to extract entity names & definitions
 

--- a/processors/locations.py
+++ b/processors/locations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (c) 2018 Miðeind ehf.
 

--- a/processors/persons.py
+++ b/processors/persons.py
@@ -1,5 +1,5 @@
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Tree processor module for extraction of person names and titles
 
@@ -22,7 +22,7 @@
     extracts person names and titles.
 
     The processor consists of a set of functions, each having the base name (without
-    variants) of a nonterminal in the Reynir context-free grammar. These functions
+    variants) of a nonterminal in the Greynir context-free grammar. These functions
     will be invoked in turn during a depth-first traversal of the tree. The functions
     are called with three parameters:
 

--- a/queries/__init__.py
+++ b/queries/__init__.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (C) 2019 Miðeind ehf.
 

--- a/queries/arithmetic.py
+++ b/queries/arithmetic.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Arithmetic query response module
 

--- a/queries/builtin.py
+++ b/queries/builtin.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Built-in query module
 

--- a/queries/bus.py
+++ b/queries/bus.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Bus schedule query module
 
@@ -21,7 +21,7 @@
 
 
     This module implements a processor for queries about bus schedules.
-    It also serves as an example of how to plug query grammars into Reynir's
+    It also serves as an example of how to plug query grammars into Greynir's
     query subsystem and how to handle the resulting trees.
 
     The queries supported by the module are as follows:

--- a/queries/currency.py
+++ b/queries/currency.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (C) 2019 Miðeind ehf.
 

--- a/queries/date.py
+++ b/queries/date.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Date query response module
 

--- a/queries/distance.py
+++ b/queries/distance.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Distance query response module
 

--- a/queries/geography.py
+++ b/queries/geography.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Geography query response module
 

--- a/queries/intro.py
+++ b/queries/intro.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Distance query response module
 

--- a/queries/location.py
+++ b/queries/location.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Location query response module
 

--- a/queries/opinion.py
+++ b/queries/opinion.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Opinion query response module
 

--- a/queries/random.py
+++ b/queries/random.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Randomness query response module
 

--- a/queries/special.py
+++ b/queries/special.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Special query response module
 

--- a/queries/stats.py
+++ b/queries/stats.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Stats query response module
 

--- a/queries/tel.py
+++ b/queries/tel.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Telephony query response module
 

--- a/queries/time.py
+++ b/queries/time.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Time query response module
 

--- a/queries/tv.py
+++ b/queries/tv.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Television schedule query response module
 

--- a/queries/unit.py
+++ b/queries/unit.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (C) 2019 Miðeind ehf.
 

--- a/queries/weather.py
+++ b/queries/weather.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Weather query response module
 

--- a/queries/wiki.py
+++ b/queries/wiki.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Wikipedia query response module
 

--- a/query.py
+++ b/query.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Query module
 

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (C) 2019 Miðeind ehf.
 

--- a/routes/api.py
+++ b/routes/api.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (C) 2019 Miðeind ehf.
 

--- a/routes/loc.py
+++ b/routes/loc.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (C) 2019 Miðeind ehf.
 

--- a/routes/main.py
+++ b/routes/main.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (C) 2019 Miðeind ehf.
 
@@ -17,7 +17,7 @@
     along with this program.  If not, see http://www.gnu.org/licenses/.
 
 
-    This module contains the main Flask routes for the Reynir web server.
+    This module contains the main Flask routes for the Greynir web server.
 
 """
 

--- a/routes/news.py
+++ b/routes/news.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (C) 2019 Miðeind ehf.
 

--- a/routes/people.py
+++ b/routes/people.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (C) 2019 Miðeind ehf.
 

--- a/routes/stats.py
+++ b/routes/stats.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (C) 2019 Miðeind ehf.
 

--- a/scraper.py
+++ b/scraper.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Scraper module
 
@@ -455,7 +455,7 @@ class Scraper:
 
 def scrape_articles(reparse=False, limit=0, urls=None, uuid=None):
 
-    logging.info("------ Reynir starting scrape -------")
+    logging.info("------ Greynir starting scrape -------")
     if uuid is not None:
         logging.info("Parsing single article with UUID {0}".format(uuid))
     elif urls is not None:
@@ -490,7 +490,7 @@ def scrape_articles(reparse=False, limit=0, urls=None, uuid=None):
 
 __doc__ = """
 
-    Reynir - Natural language processing for Icelandic
+    Greynir - Natural language processing for Icelandic
 
     Scraper module
 

--- a/scrapers/__init__.py
+++ b/scrapers/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     scraper folder
 

--- a/scrapers/default.py
+++ b/scrapers/default.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Default scraping helpers module
 

--- a/scrapers/reykjanes.py
+++ b/scrapers/reykjanes.py
@@ -1,5 +1,5 @@
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Special scraping module for preloaded local data
     used for entiment analysis experiment

--- a/scripts/.ipython.py
+++ b/scripts/.ipython.py
@@ -1,4 +1,4 @@
-# Reynir configuration file for ipython.
+# Greynir configuration file for ipython.
 
 from platform import python_version, python_implementation
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,7 +35,7 @@ sudo systemctl stop $SERVICE
 
 cd $DEST
 
-# echo "Upgrading the reynir package"
+# echo "Upgrading the Greynir package"
 
 # source p369/bin/activate
 # pip install --upgrade -r requirements.txt

--- a/scripts/start-greynir.sh
+++ b/scripts/start-greynir.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-# Shell script to start Gunicorn running Reynir (greynir.is)
+# Shell script to start Gunicorn running Greynir (greynir.is)
 
 cd /usr/share/nginx/greynir.is
 source p3510/bin/activate

--- a/search.py
+++ b/search.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Search module
 

--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,5 @@
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Settings module
 

--- a/similar.py
+++ b/similar.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env/python
 
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Similarity query client
 

--- a/speech.py
+++ b/speech.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (C) 2019 Miðeind ehf.
 

--- a/static/css/main-bootstrap.css
+++ b/static/css/main-bootstrap.css
@@ -2,7 +2,7 @@
 
    main-bootstrap.css
 
-   CSS file for Reynir front-end web
+   CSS file for Greynir web front-end
 
    Copyright (C) 2018 Miðeind ehf.
 

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1,7 +1,7 @@
 
 /*
 
-   Reynir: Natural language processing for Icelandic
+   Greynir: Natural language processing for Icelandic
 
    Common.js
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2,7 +2,7 @@
 
    Main.js
 
-   Reynir/Greynir front page script
+   Greynir front page script
 
     Copyright (C) 2018 Miðeind ehf.
 

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -1,6 +1,6 @@
 /*
 
-   Reynir: Natural language processing for Icelandic
+   Greynir: Natural language processing for Icelandic
 
    Page.js
 

--- a/tests/test_greynir.py
+++ b/tests/test_greynir.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (C) 2019 Miðeind ehf.
 
@@ -17,7 +17,7 @@
     along with this program.  If not, see http://www.gnu.org/licenses/.
 
 
-    Tests for code in the Reynir repo.
+    Tests for code in the Greynir repo.
 
 """
 

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Copyright (C) 2019 Miðeind ehf.
 

--- a/tnttagger.py
+++ b/tnttagger.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     TnT Tagger module
 

--- a/tree.py
+++ b/tree.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Tree module
 
@@ -1252,7 +1252,7 @@ class TreeBase:
                 self.stack = self.stack[0 : n + 1]
 
     def handle_R(self, n):
-        """ Reynir version info """
+        """ Greynir version info """
         pass
 
     def handle_C(self, n):

--- a/treeutil.py
+++ b/treeutil.py
@@ -1,6 +1,6 @@
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     TreeUtility class
 

--- a/utils/addgender.py
+++ b/utils/addgender.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Utility program to populate the gender column of the persons table
 

--- a/utils/cmp.py
+++ b/utils/cmp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     POS tagging accuracy measurement tool
 
@@ -21,7 +21,7 @@
     along with this program.  If not, see http://www.gnu.org/licenses/.
 
 
-    This module allows measurement of POS tagging accuracy for Reynir
+    This module allows measurement of POS tagging accuracy for Greynir
     against the Icelandic Frequency Database (IFD), which is a hand-tagged
     corpus containing various types of text.
 
@@ -1342,12 +1342,12 @@ class Comparison():
         corpus = Corpus()
         sentences = corpus.raw_sentence_stream(filter_func = filter_func, skip = skip_func)
         if USE_LOCAL_TAGGER:
-            # Call the Reynir POS tagger directly in-process
+            # Call the Greynir POS tagger directly in-process
             with Tagger.session() as tagger:
                 for sent in sentences:
                     process_func(tagger, sent)
         else:
-            # Use the Reynir HTTP JSON API for POS tagging (/postag.api)
+            # Use the Greynir HTTP JSON API for POS tagging (/postag.api)
             for sent in sentences:
                 process_func(None, sent)
         self.prenta()

--- a/utils/dawgbuilder.py
+++ b/utils/dawgbuilder.py
@@ -8,7 +8,7 @@
     to store a large set of words in an efficient structure
     in terms of storage and speed.
 
-    Reynir uses three DAWGs to implement its compound word recognizer
+    Greynir uses three DAWGs to implement its compound word recognizer
     for Icelandic. They contain the entire BÍN database of word forms,
     all allowable word prefixes, and all allowable word suffixes,
     respectively.
@@ -844,7 +844,7 @@ class DawgBuilder:
 
 def generate_dawgs():
     """ Build all required DAWGs """
-    print("Starting DAWG build for Reynir")
+    print("Starting DAWG build for Greynir")
     resources_path = os.path.join(basepath, "resources")
     db = DawgBuilder()
 
@@ -886,7 +886,7 @@ def generate_dawgs():
 
 if __name__ == "__main__":
 
-    # Build the DAWGs for the Reynir compound word recognizer.
+    # Build the DAWGs for the Greynir compound word recognizer.
     # !!! Note: We can't use the IS_is.utf8 locale's default
     # collation order, since it is case-insignificant. We must
     # use a collation order that is case-significant for the

--- a/utils/dumper.py
+++ b/utils/dumper.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Dumper module
 
@@ -183,7 +183,7 @@ class Dumper:
 
 def process_articles(limit = 0):
 
-    print("------ Reynir starting dump -------")
+    print("------ Greynir starting dump -------")
     print("Output file: {0}".format(OUTPUT_FILE))
     if limit:
         print("Limit: {0} articles".format(limit))
@@ -210,7 +210,7 @@ class Usage(Exception):
 
 __doc__ = """
 
-    Reynir - Natural language processing for Icelandic
+    Greynir - Natural language processing for Icelandic
 
     Dumper module
 

--- a/utils/mim.py
+++ b/utils/mim.py
@@ -1,5 +1,5 @@
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     MIM corpus test module
 
@@ -13,7 +13,7 @@
 
     This module parses XML files in the TEI format from the
     MIM corpus ('Mörkuð íslensk málheild') and compares the POS
-    tags in the corpus with output from Reynir  
+    tags in the corpus with output from Greynir
 
 """
 
@@ -130,13 +130,13 @@ def parse_tokens(toklist, mim_tags, fast_p):
             # Check whether the token streams are in sync
             if tag_ix < ntags and t[1] != mim_tags[tag_ix][1]:
                 #print("Warning: mismatch between MIM token '{0}' and Reynir token '{1}'".format(mim_tags[tag_ix][1], t[1]))
-                # Attempt to sync again by finding the Reynir token in the MIM tag stream
+                # Attempt to sync again by finding the Greynir token in the MIM tag stream
                 gap = 1
                 MAX_LOOKAHEAD = 4
                 while gap < MAX_LOOKAHEAD and (tag_ix + gap) < ntags and mim_tags[tag_ix + gap][1] != t[1]:
                     gap += 1
                 if gap < MAX_LOOKAHEAD:
-                    # Found the Reynir token ahead
+                    # Found the Greynir token ahead
                     #print("Re-synced by skipping ahead by {0} tokens".format(gap))
                     tag_ix += gap
             if tag_ix < ntags:
@@ -253,7 +253,7 @@ if __name__ == "__main__":
         print("Configuration error: {0}".format(e))
         quit()
 
-    print("Running Reynir with debug={0}, host={1}, db_hostname={2}"
+    print("Running Greynir with debug={0}, host={1}, db_hostname={2}"
         .format(Settings.DEBUG, Settings.HOST, Settings.DB_HOSTNAME))
 
     with Fast_Parser(verbose = False) as fast_p:

--- a/utils/pairgen.py
+++ b/utils/pairgen.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Text and parse tree pair generator
 
@@ -142,7 +142,7 @@ def write_shuffled_files(outfile_dev, outfile_train, generator, dev_size, train_
 
 def main(dev_size, train_size, shuffle, scores):
 
-    print("Welcome to the Reynir text and parse tree pair generator")
+    print("Welcome to the Greynir text and parse tree pair generator")
 
     try:
         # Read configuration file

--- a/utils/ptest.py
+++ b/utils/ptest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Parser test module
 

--- a/utils/tagtest.py
+++ b/utils/tagtest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Tagging test and training program
 

--- a/utils/trainer.py
+++ b/utils/trainer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     POS tagger training program
 

--- a/utils/trigrams.py
+++ b/utils/trigrams.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Trigrams module
 

--- a/utils/verbs.py
+++ b/utils/verbs.py
@@ -2,7 +2,7 @@
 
 """
 
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Verb information collector
 
@@ -22,7 +22,7 @@
 
 
     This module reads information about Icelandic verbs from a text
-    file and emits it in a format usable by Reynir.
+    file and emits it in a format usable by Greynir.
 
 """
 

--- a/utils/vocab.py
+++ b/utils/vocab.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
     
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Additional vocabulary utility
 
@@ -320,7 +320,7 @@ class Meanings:
 
 if __name__ == "__main__":
 
-    print("Welcome to the Reynir additional vocabulary builder\n")
+    print("Welcome to the Greynir additional vocabulary builder\n")
 
     src = os.path.join(basepath, "config", "Vocab.conf")
     fname = os.path.join(basepath, "resources", "ord.add.csv")

--- a/vectors/Vectors.conf
+++ b/vectors/Vectors.conf
@@ -1,7 +1,7 @@
 #
 # Vectors.conf
 #
-# Configuration file for Reynir (vectors subsystem)
+# Configuration file for Greynir (vectors subsystem)
 #
 # Copyright (C) 2016 Vilhjálmur Þorsteinsson
 #

--- a/vectors/builder.py
+++ b/vectors/builder.py
@@ -1,5 +1,5 @@
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Document index builder & topic tagger module
 
@@ -20,7 +20,7 @@
 
     This module is written in Python 3
 
-    This module reads articles from the Reynir article database as bags-of-words
+    This module reads articles from the Greynir article database as bags-of-words
     and indexes them using Latent Semantic Indexing (LSI, also called Latent Semantic
     Analysis, LSA), with indexes generated with the help of the Gensim document
     processing module.
@@ -78,7 +78,7 @@ def w_from_stem(stem, cat):
 
 class CorpusIterator:
 
-    """ Iterate through the Reynir words database, yielding a bag-of-words
+    """ Iterate through the Greynir words database, yielding a bag-of-words
         for each article """
 
     def __init__(self, dictionary=None):
@@ -559,7 +559,7 @@ class ReynirCorpus:
 def build_model(verbose=False):
     """ Build a new model from the words (and articles) table """
 
-    print("------ Reynir starting model build -------")
+    print("------ Greynir starting model build -------")
     ts = "{0}".format(datetime.utcnow())[0:19]
     print("Time: {0}".format(ts))
 
@@ -589,18 +589,18 @@ def build_model(verbose=False):
 def calculate_topics(verbose=False):
     """ Recalculate topic vectors from keywords """
 
-    print("------ Reynir recalculating topic vectors -------")
+    print("------ Greynir recalculating topic vectors -------")
     rc = ReynirCorpus(verbose=verbose)
     rc.load_lsi_model()
     rc.calculate_topics()
-    print("------ Reynir recalculation complete -------")
+    print("------ Greynir recalculation complete -------")
 
 
 def tag_articles(limit, verbose=False, process_all=False, uuid=None):
     """ Tag all untagged articles or articles that
         have been parsed since they were tagged """
 
-    print("------ Reynir starting tagging -------")
+    print("------ Greynir starting tagging -------")
     if uuid:
         print("Tagging article {0}".format(uuid))
     elif process_all:
@@ -641,7 +641,7 @@ class Usage(Exception):
 
 __doc__ = """
 
-    Reynir - Natural language processing for Icelandic
+    Greynir - Natural language processing for Icelandic
 
     Index builder and tagger module
 

--- a/vectors/simserver.py
+++ b/vectors/simserver.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env/python
 
 """
-    Reynir: Natural language processing for Icelandic
+    Greynir: Natural language processing for Icelandic
 
     Similarity query server
 
@@ -29,7 +29,7 @@
     For security, this port should be closed from outside access via iptables or
     a firewall. However, the server also requires the client to authenticate
     using a secret key that is loaded from resources/SimilarityServerKey.txt.
-    This file should not be made visible outside the Reynir server (or local
+    This file should not be made visible outside the Greynir server (or local
     network).
 
     To register this program as a service within systemd, create a unit file
@@ -239,7 +239,7 @@ class SimilarityServer:
             )
 
         print(
-            "Reynir similarity server started\nListening for connections on port {0}".format(
+            "Greynir similarity server started\nListening for connections on port {0}".format(
                 port
             )
         )


### PR DESCRIPTION
Doesn't change the name of any files, classes, etc. and should not affect functionality.
I suggest that configuration filenames and class names be migrated as well, so we can standardise on the single, canonical name.