### PR TITLE
Correct grammar for statistics of paragraph analysis

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -188,7 +188,7 @@ function correctPlural(c, one, singular, plural) {
    // 11 greinum, 7 greinum
    return c.toString() + " " + plural;
 }
-exports.correctPlural = correctPlural
+
 function makeSourceList(sources) {
    // Return a HTML rendering of a list of articles where the person or entity name appears
    if (!sources)

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -188,7 +188,7 @@ function correctPlural(c, one, singular, plural) {
    // 11 greinum, 7 greinum
    return c.toString() + " " + plural;
 }
-
+exports.correctPlural = correctPlural
 function makeSourceList(sources) {
    // Return a HTML rendering of a list of articles where the person or entity name appears
    if (!sources)

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -441,13 +441,14 @@ function displayTokens(j) {
 
 function populateStats(stats) {
    var parsedRatio = stats.num_sentences > 0 ? format_is(100.0 * stats.num_parsed / stats.num_sentences, 1) : "0.0"
-   $("#statistics-summary").append(
+   var statisticsSummary = $("#statistics-summary")
+   statisticsSummary.append(
       `<li>Textinn inniheldur ${correctPlural(stats.num_tokens, "eina", "eind", "eindir")} í ${correctPlural(stats.num_sentences, "einni", "málsgrein.", "málsgreinum")}</li>`
    )
-   $("#statistics-summary").append(
+   statisticsSummary.append(
       `<li>Það tókst að trjágreina ${correctPlural(stats.num_parsed, "eina", "málsgrein", "málsgreinar")} eða ${parsedRatio}%.</li>`
    )
-   $("#statistics-summary").append(
+   statisticsSummary.append(
       `<li>Margræðnistuðull var ${format_is(stats.ambiguity, 2)}.</li>`
    )
    $("div#statistics").css("display", "block");

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -37,8 +37,6 @@
 
 */
 
-var correctPlural = require("./main")
-
 // Punctuation types
 
 var TP_LEFT = 1;
@@ -447,7 +445,7 @@ function populateStats(stats) {
       `<li>Textinn inniheldur ${correctPlural(stats.num_tokens, "eina", "eind", "eindir")} í ${correctPlural(stats.num_sentences, "einni", "málsgrein.", "málsgreinum")}</li>`
    )
    $("#statistics-summary").append(
-      `<li>Það tókst að trjágreina ${stats.num_parsed, "eina", "málsgrein", "málsgreinar"} eða ${parsedRatio}%.</li>`
+      `<li>Það tókst að trjágreina ${correctPlural(stats.num_parsed, "eina", "málsgrein", "málsgreinar")} eða ${parsedRatio}%.</li>`
    )
    $("#statistics-summary").append(
       `<li>Margræðnistuðull var ${format_is(stats.ambiguity, 2)}.</li>`

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -37,8 +37,6 @@
 
 */
 
-// import { correctPlural } from "./main"
-
 var correctPlural = require("./main")
 
 // Punctuation types

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -442,11 +442,12 @@ function displayTokens(j) {
 function populateStats(stats) {
    $("#tok-num").text(format_is(stats.num_tokens));
    $("#num-sent").text(format_is(stats.num_sentences));
+   $("#paragraphs-contained").text(stats.num_sentences === 1 ? "málsgrein." : "málsgreinum.")
    $("#num-parsed-sent").text(format_is(stats.num_parsed));
    if (stats.num_parsed == 1) {
-      $("#paragraphs").text("málsgrein")
+      $("#paragraphs-analyzed").text("málsgrein")
    } else {
-      $("#paragraphs").text("málsgreinar");
+      $("#paragraphs-analyzed").text("málsgreinar");
    }
    if (stats.num_sentences > 0) {
       $("#num-parsed-ratio").text(format_is(100.0 * stats.num_parsed / stats.num_sentences, 1));

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -440,8 +440,9 @@ function displayTokens(j) {
 }
 
 function populateStats(stats) {
-   var parsedRatio = stats.num_sentences > 0 ? format_is(100.0 * stats.num_parsed / stats.num_sentences, 1) : "0.0"
-   var statisticsSummary = $("#statistics-summary")
+   var parsedRatio = stats.num_sentences > 0 ? format_is(10 * stats.num_parsed / stats.num_sentences, 1) : "0,0";
+   var statisticsSummary = $("#statistics-summary");
+   statisticsSummary.html("");
    statisticsSummary.append(
       `<li>Textinn inniheldur ${correctPlural(stats.num_tokens, "eina", "eind", "eindir")} í ${correctPlural(stats.num_sentences, "einni", "málsgrein.", "málsgreinum")}</li>`
    )

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -37,6 +37,10 @@
 
 */
 
+// import { correctPlural } from "./main"
+
+var correctPlural = require("./main")
+
 // Punctuation types
 
 var TP_LEFT = 1;
@@ -440,22 +444,16 @@ function displayTokens(j) {
 }
 
 function populateStats(stats) {
-   $("#tok-num").text(format_is(stats.num_tokens));
-   $("#tok-contained").text(stats.num_tokens === 1 ? " eind " : " eindir ")
-   $("#num-sent").text(format_is(stats.num_sentences))
-   $("#paragraphs-contained").text(stats.num_sentences === 1 ? "málsgrein." : "málsgreinum.")
-   $("#num-parsed-sent").text(format_is(stats.num_parsed));
-   if (stats.num_parsed == 1) {
-      $("#paragraphs-analyzed").text("málsgrein")
-   } else {
-      $("#paragraphs-analyzed").text("málsgreinar");
-   }
-   if (stats.num_sentences > 0) {
-      $("#num-parsed-ratio").text(format_is(100.0 * stats.num_parsed / stats.num_sentences, 1));
-   } else {
-      $("#num-parsed-ratio").text("0.0");
-   }
-   $("#avg-ambig-factor").text(format_is(stats.ambiguity, 2));
+   var parsedRatio = stats.num_sentences > 0 ? format_is(100.0 * stats.num_parsed / stats.num_sentences, 1) : "0.0"
+   $("#statistics-summary").append(
+      `<li>Textinn inniheldur ${correctPlural(stats.num_tokens, "eina", "eind", "eindir")} í ${correctPlural(stats.num_sentences, "einni", "málsgrein.", "málsgreinum")}</li>`
+   )
+   $("#statistics-summary").append(
+      `<li>Það tókst að trjágreina ${stats.num_parsed, "eina", "málsgrein", "málsgreinar"} eða ${parsedRatio}%.</li>`
+   )
+   $("#statistics-summary").append(
+      `<li>Margræðnistuðull var ${format_is(stats.ambiguity, 2)}.</li>`
+   )
    $("div#statistics").css("display", "block");
 }
 

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -445,13 +445,13 @@ function populateStats(stats) {
    statisticsSummary.html("");
    statisticsSummary.append(
       `<li>Textinn inniheldur ${correctPlural(stats.num_tokens, "eina", "eind", "eindir")} í ${correctPlural(stats.num_sentences, "einni", "málsgrein.", "málsgreinum")}</li>`
-   )
+   );
    statisticsSummary.append(
       `<li>Það tókst að trjágreina ${correctPlural(stats.num_parsed, "eina", "málsgrein", "málsgreinar")} eða ${parsedRatio}%.</li>`
-   )
+   );
    statisticsSummary.append(
       `<li>Margræðnistuðull var ${format_is(stats.ambiguity, 2)}.</li>`
-   )
+   );
    $("div#statistics").css("display", "block");
 }
 

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -441,7 +441,8 @@ function displayTokens(j) {
 
 function populateStats(stats) {
    $("#tok-num").text(format_is(stats.num_tokens));
-   $("#num-sent").text(format_is(stats.num_sentences));
+   $("#tok-contained").text(stats.num_tokens === 1 ? " eind " : " eindir ")
+   $("#num-sent").text(format_is(stats.num_sentences))
    $("#paragraphs-contained").text(stats.num_sentences === 1 ? "málsgrein." : "málsgreinum.")
    $("#num-parsed-sent").text(format_is(stats.num_parsed));
    if (stats.num_parsed == 1) {

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -53,14 +53,8 @@
    <div id="statistics">
       <!-- Statistics go here -->
       <h3>Tölfræði</h3>
-      <ul>
-         <li>Textinn inniheldur <span id="tok-num">0</span> eindir í
-            <span id="num-sent">0</span> málsgreinum.</li>
-         <li>Það tókst að greina <span id="num-parsed-sent">0</span>
-            <span id="paragraphs">málsgreinar</span> eða
-            <span id="num-parsed-ratio">0,0</span>%.</li>
-         <li>Margræðnistuðull var
-            <span id="avg-ambig-factor">1,00</span>.</li>
+      <ul id="statistics-summary">
+         <!-- Statistics get populated in page.js -->
       </ul>
    </div>
 

--- a/templates/correct.html
+++ b/templates/correct.html
@@ -96,7 +96,8 @@
             <!-- Statistics go here -->
             <h3>Tölfræði</h3>
             <ul>
-               <li>Textinn inniheldur <span id="tok-num">0</span> eindir í
+               <li>Textinn inniheldur <span id="tok-num">0</span> 
+                  <span id="tokens-contained"> eindir </span>í
                   <span id="num-sent">0</span> 
                   <span id="paragraphs-contained">málsgreinum.</span></li>
                <li>Það tókst að trjágreina <span id="num-parsed-sent">0</span>

--- a/templates/correct.html
+++ b/templates/correct.html
@@ -97,9 +97,10 @@
             <h3>Tölfræði</h3>
             <ul>
                <li>Textinn inniheldur <span id="tok-num">0</span> eindir í
-                  <span id="num-sent">0</span> málsgreinum.</li>
+                  <span id="num-sent">0</span> 
+                  <span id="paragraphs-contained">málsgreinum.</span></li>
                <li>Það tókst að trjágreina <span id="num-parsed-sent">0</span>
-                  <span id="paragraphs">málsgreinar</span> eða
+                  <span id="paragraphs-analyzed">málsgreinar</span> eða
                   <span id="num-parsed-ratio">0,0</span>%.</li>
                <li>Margræðnistuðull var
                   <span id="avg-ambig-factor">1,00</span>.</li>

--- a/templates/correct.html
+++ b/templates/correct.html
@@ -95,16 +95,8 @@
          <div id="statistics">
             <!-- Statistics go here -->
             <h3>Tölfræði</h3>
-            <ul>
-               <li>Textinn inniheldur <span id="tok-num">0</span> 
-                  <span id="tokens-contained"> eindir </span>í
-                  <span id="num-sent">0</span> 
-                  <span id="paragraphs-contained">málsgreinum.</span></li>
-               <li>Það tókst að trjágreina <span id="num-parsed-sent">0</span>
-                  <span id="paragraphs-analyzed">málsgreinar</span> eða
-                  <span id="num-parsed-ratio">0,0</span>%.</li>
-               <li>Margræðnistuðull var
-                  <span id="avg-ambig-factor">1,00</span>.</li>
+            <ul id="statistics-summary">
+                  <!-- Statistics get populated in page.js -->
             </ul>
          </div>
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -187,13 +187,8 @@
    <div id="statistics">
       <!-- Statistics go here -->
       <h3>Tölfræði</h3>
-      <ul>
-         <li>Textinn inniheldur <span id="tok-num">0</span> eindir í
-            <span id="num-sent">0</span> málsgreinum.</li>
-         <li>Það tókst að trjágreina <span id="num-parsed-sent">0</span> málsgreinar eða
-            <span id="num-parsed-ratio">0,0</span>%.</li>
-         <li>Margræðnistuðull var
-            <span id="avg-ambig-factor">1,00</span>.</li>
+      <ul id="statistics-summary">
+         <!-- Statistics get populated in page.js -->
       </ul>
    </div>
 


### PR DESCRIPTION
<img width="432" alt="Screenshot 2020-05-06 at 14 35 37" src="https://user-images.githubusercontent.com/7723013/81180610-90382680-8fab-11ea-8b18-c69905d37394.png">
Er ekki lenska að nota ensku hérna?

I was playing with Greynir and came across this minor issue shown in the screenshot. There is an underlying issue in that three words here don't correctly handle the value being 1, 21, 31,41, etc. These statistics  are displayed in three places so a fix would have been required in all three. Instead I refactored the module to get generated in one place for all three. This furthermore reduces work for jQuery from finding 6 nodes down to 1.