### PR TITLE
Minor format() fixes in tel and ja query modules

### DIFF
--- a/queries/ja.py
+++ b/queries/ja.py
@@ -235,7 +235,7 @@ def _answer_name4phonenum_query(q: Query, result: Result) -> AnswerTuple:
     q.set_expires(datetime.utcnow() + timedelta(hours=24))
 
     if not clean_num or len(clean_num) < 3:
-        return gen_answer("{0} er ekki gilt símanúmer")
+        return gen_answer("{0} er ekki gilt símanúmer".format(num))
 
     res = query_ja_api(clean_num)
 

--- a/queries/tel.py
+++ b/queries/tel.py
@@ -216,7 +216,7 @@ def handle_plain_text(q: Query) -> bool:
         clean_num = re.sub(r"[^0-9]", "", telsubj).strip()
         if len(clean_num) < 3:
             # The number is clearly not a valid phone number
-            a = gen_answer("{0} er ekki gilt símanúmer.".format(number))
+            a = gen_answer("{0} er ekki gilt símanúmer.".format(telsubj))
         elif re.search(r"^[\d|\s]+$", clean_num):
             # At this point we have what looks like a legitimate phone number.
             # Send tel: url to trigger phone call in client


### PR DESCRIPTION
Call to format() in tel.py always inserted "None". Added missing format() in ja.py so output isn't "{0} er ekki gilt símanúmer".

