### PR TITLE
Radio schedules

### DIFF
--- a/queries/schedules.py
+++ b/queries/schedules.py
@@ -118,6 +118,7 @@ QScheduleRadio →
 
 QSchRadioStationNowQuery →
     QSchWhatIsNom QSchEiginlega? QSchGoingOn? QSchOnRadioStation QSchNow?
+    | QSchWhatIsNom QSchEiginlega? QSchOnSchedule? QSchOnRadioStation QSchNow?
     | QSchWhatIsDative QSchEiginlega? "verið" "að" "spila" QSchOnRadioStation QSchNow?
 
 QSchWhatIsNom →

--- a/queries/schedules.py
+++ b/queries/schedules.py
@@ -57,7 +57,9 @@ TOPIC_LEMMAS = [
     "útvarp",
     "ríkisútvarp",
     "rás",
+    "útvarpsrás",
     "þáttur",
+    "útvarpsþáttur",
 ]
 
 
@@ -125,10 +127,16 @@ QSchRadioStationNowQuery →
     | QSchWhatIsDative QSchEiginlega? "verið" "að" "spila" QSchOnRadioStation QSchNow?
 
 QSchWhatIsNom →
-    "hvað" "er" | "hvaða" "þáttur" "er" | "hvaða" "dagskrárliður" "er" | "hvaða" "efni" "er"
+    "hvað" "er"
+    | "hvaða" "þáttur" "er"
+    | "hvaða" "dagskrárliður" "er"
+    | "hvaða" "efni" "er"
 
 QSchWhatIsDative →
-    "hvað" "er" | "hvaða" "þátt" "er" | "hvaða" "dagskrárlið" "er" | "hvaða" "efni" "er"
+    "hvað" "er"
+    | "hvaða" "þátt" "er"
+    | "hvaða" "dagskrárlið" "er"
+    | "hvaða" "efni" "er"
 
 QSchOnTV →
     QSchOnRUV # | QSchOnStod2

--- a/queries/schedules.py
+++ b/queries/schedules.py
@@ -331,9 +331,7 @@ def _gen_curr_tv_program_answer(q: Query, result: Result) -> AnswerTuple:
 
     title = prog["title"]
     ep = "" if "fréttir" in title.lower() else ""
-    answ = "RÚV er að sýna {0}{1}. {2}.".format(
-        ep, title, _clean_desc(prog["description"])
-    )
+    answ = f"RÚV er að sýna {ep}{title}. {_clean_desc(prog['description'])}."
     return gen_answer(answ)
 
 
@@ -349,7 +347,7 @@ def _gen_evening_tv_program_answer(q: Query, result: Result) -> AnswerTuple:
 
     answ = ["Klukkan"]
     for p in prog:
-        answ.append("{0} : {1}.\n".format(p["startTime"][11:16], p["title"]))
+        answ.append(f"{p['startTime'][11:16]} : {p['title']}.\n")
     voice_answer = "".join(answ)
     answer = "".join(answ[1:]).replace(" : ", " ")
     return dict(answer=answer), answer, voice_answer
@@ -400,9 +398,9 @@ def sentence(state: QueryStateDict, result: Result) -> None:
             q.set_expires(datetime.utcnow() + timedelta(minutes=3))
         except Exception as e:
             logging.warning(
-                "Exception while processing TV schedule query: {0}".format(e)
+                f"Exception while processing TV schedule query: {e}"
             )
-            q.set_error("E_EXCEPTION: {0}".format(e))
+            q.set_error(f"E_EXCEPTION: {e}")
 
     else:
         q.set_error("E_QUERY_NOT_UNDERSTOOD")

--- a/queries/schedules.py
+++ b/queries/schedules.py
@@ -134,8 +134,14 @@ QSchOnTV →
     QSchOnRUV # | QSchOnStod2
 
 QSchOnRUV →
-    "í" "sjónvarpinu" | "á" "rúv" | "í" "ríkissjónvarpinu"
-    | "á" "stöð" "eitt" | "hjá"? "rúv" | "sjónvarpsins" | "sjónvarps"
+    "í" "sjónvarpinu"
+    | "á" "rúv"
+    | "í" "ríkissjónvarpinu"
+    | "á" "stöð" "eitt"
+    | "hjá" "stöð" "eitt"
+    | "hjá"? "rúv"
+    | "sjónvarpsins"
+    | "sjónvarps"
 
 QSchOnStod2 →
     "á" "stöð" "tvö" | "á" "stöð" "2"
@@ -146,17 +152,22 @@ QSchOnRadioStation →
 
 QSchOnSernafn →
     # Catch when Rás 1/2 is typed with uppercase R
-    "á" Sérnafn
+    "á" Sérnafn | "hjá" Sérnafn
 
 QSchOnRas1 →
     "á" "rás" "eitt"
     | "á" "rás" "1"
+    | "hjá" "rás" "eitt"
+    | "hjá" "rás" "1"
     | "í" "útvarpinu"
     | "í" "ríkisútvarpinu"
     | "á" "ríkisútvarpinu"
 
 QSchOnRas2 →
-    "á" "rás" "tvö" | "á" "rás" "2"
+    "á" "rás" "tvö"
+    | "á" "rás" "2"
+    | "hjá" "rás" "tvö"
+    | "hjá" "rás" "2"
 
 QSchNow →
     "nákvæmlega"? "núna" | "eins" "og" "stendur" | "í" "augnablikinu"
@@ -190,10 +201,10 @@ $score(+55) QSchedule
 
 
 def QSchOnSernafn(node: Node, params: ParamList, result: Result) -> None:
-    if result._nominative == "á Rás 1":
+    if result._nominative == "á Rás 1" or result._nominative == "hjá Rás 1":
         result["radio_channel"] = "ras1"
         result["radio_channel_pretty"] = "Rás 1"
-    elif result._nominative == "á Rás 2":
+    elif result._nominative == "á Rás 2" or result._nominative == "hjá Rás 2":
         result["radio_channel"] = "ras2"
         result["radio_channel_pretty"] = "Rás 2"
     else:

--- a/queries/schedules.py
+++ b/queries/schedules.py
@@ -235,8 +235,8 @@ def _clean_desc(d: str) -> str:
 
 _TV_SCHEDULE_API_ENDPOINT = "https://apis.is/tv/{0}/"
 _TV_API_ERRMSG = "Ekki tókst að sækja sjónvarpsdagskrá."
-_TV_SCHED_CACHE: Optional[List] = None
-_TV_LAST_FETCHED: Optional[datetime] = None
+_TV_SCHED_CACHE: Dict[str, List] = {}
+_TV_LAST_FETCHED: Dict[str, List] = {}
 
 
 def _query_tv_schedule_api(channel: str = "ruv") -> Optional[List]:
@@ -244,17 +244,16 @@ def _query_tv_schedule_api(channel: str = "ruv") -> Optional[List]:
     global _TV_SCHED_CACHE
     global _TV_LAST_FETCHED
     if (
-        not _TV_SCHED_CACHE
-        or not _TV_LAST_FETCHED
-        or _TV_LAST_FETCHED.date() != datetime.today().date()
+        not _TV_SCHED_CACHE.get(channel)
+        or not _TV_LAST_FETCHED.get(channel)
+        or _TV_LAST_FETCHED[channel].date() != datetime.today().date()
     ):
         # Not cached. Fetch data.
-        _TV_SCHED_CACHE = None
         sched = query_json_api(_TV_SCHEDULE_API_ENDPOINT.format(channel))
         if sched and "results" in sched and len(sched["results"]):
-            _TV_LAST_FETCHED = datetime.utcnow()
-            _TV_SCHED_CACHE = sched["results"]
-    return _TV_SCHED_CACHE
+            _TV_LAST_FETCHED[channel] = datetime.utcnow()
+            _TV_SCHED_CACHE[channel] = sched["results"]
+    return _TV_SCHED_CACHE.get(channel)
 
 
 _RADIO_SCHEDULE_API_ENDPOINT = "https://muninn.ruv.is/files/json/{0}/{1}/"

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -594,11 +594,11 @@ def test_query_api(client):
     json = qmcall(c, {"q": "hver er sjónvarpsdagskráin í kvöld?"}, "Schedule")
     assert json["key"] == "TelevisionEvening"
     json = qmcall(c, {"q": "hvað er í útvarpinu núna?"}, "Schedule")
-    assert json["qkey"] == "RadioSchedule"
+    assert json["key"] == "RadioSchedule"
     json = qmcall(c, {"q": "hvað er eiginlega í gangi á rás eitt?"}, "Schedule")
-    assert json["qkey"] == "RadioSchedule"
+    assert json["key"] == "RadioSchedule"
     json = qmcall(c, {"q": "hvað er á dagskrá á rás tvö?"}, "Schedule")
-    assert json["qkey"] == "RadioSchedule"
+    assert json["key"] == "RadioSchedule"
 
     # Special module
     json = qmcall(client, {"q": "Hver er sætastur?", "voice": True}, "Special")

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -593,12 +593,12 @@ def test_query_api(client):
     assert json["key"] == "TelevisionEvening"
     json = qmcall(c, {"q": "hver er sjónvarpsdagskráin í kvöld?"}, "Schedule")
     assert json["key"] == "TelevisionEvening"
-    # json = qmcall(c, {"q": "hvað er í útvarpinu núna?"}, "Schedule")
-    # assert json["qkey"] == "RadioSchedule"
-    # json = qmcall(c, {"q": "hvað er eiginlega í gangi á rás eitt?"}, "Schedule")
-    # assert json["qkey"] == "RadioSchedule"
-    # json = qmcall(c, {"q": "hvað er á dagskrá á rás tvö?"}, "Schedule")
-    # assert json["qkey"] == "RadioSchedule"
+    json = qmcall(c, {"q": "hvað er í útvarpinu núna?"}, "Schedule")
+    assert json["qkey"] == "RadioSchedule"
+    json = qmcall(c, {"q": "hvað er eiginlega í gangi á rás eitt?"}, "Schedule")
+    assert json["qkey"] == "RadioSchedule"
+    json = qmcall(c, {"q": "hvað er á dagskrá á rás tvö?"}, "Schedule")
+    assert json["qkey"] == "RadioSchedule"
 
     # Special module
     json = qmcall(client, {"q": "Hver er sætastur?", "voice": True}, "Special")

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -595,9 +595,15 @@ def test_query_api(client):
     assert json["key"] == "TelevisionEvening"
     json = qmcall(c, {"q": "hvað er í útvarpinu núna?"}, "Schedule")
     assert json["key"] == "RadioSchedule"
-    json = qmcall(c, {"q": "hvað er eiginlega í gangi á rás eitt?"}, "Schedule")
+    json = qmcall(c, {"q": "hvað er eiginlega í gangi á Rás eitt?"}, "Schedule")
     assert json["key"] == "RadioSchedule"
     json = qmcall(c, {"q": "hvað er á dagskrá á rás tvö?"}, "Schedule")
+    assert json["key"] == "RadioSchedule"
+    json = qmcall(c, {"q": "hvað er á Rás 1?"}, "Schedule")
+    assert json["key"] == "RadioSchedule"
+    json = qmcall(c, {"q": "hvað er á Rás 2?"}, "Schedule")
+    assert json["key"] == "RadioSchedule"
+    json = qmcall(c, {"q": "hvaða þáttur er í gangi á rás tvö núna?"}, "Schedule")
     assert json["key"] == "RadioSchedule"
 
     # Special module


### PR DESCRIPTION
Added Rás 1 and Rás 2 schedule querying to queries/schedules.py.
Minor changes to TV schedule functionality to prepare better for multiple channels.
(Was going to add querying for other TV channels than RÚV but the endpoints don't seem to work on apis.is)