### PR TITLE
Number to text functions

### DIFF
--- a/queries/__init__.py
+++ b/queries/__init__.py
@@ -52,6 +52,7 @@ from tzwhere import tzwhere  # type: ignore
 from pytz import country_timezones
 
 from geo import country_name_for_isocode, iceprep_for_cc
+from queries.num import number_to_text, float_to_text
 from reynir import NounPhrase
 from settings import changedlocale
 from util import read_api_key
@@ -255,7 +256,9 @@ _TIMEUNIT_INTERVALS = (
 _CASE_ABBR = ["nf", "þf", "þgf", "ef"]
 
 
-def time_period_desc(seconds: int, case: str = "nf", omit_seconds: bool = True) -> str:
+def time_period_desc(
+    seconds: int, case: str = "nf", omit_seconds: bool = True, num_to_str: bool = False
+) -> str:
     """Generate Icelandic description of the length of a given time
     span, e.g. "4 dagar, 6 klukkustundir og 21 mínúta."""
     assert case in _CASE_ABBR
@@ -271,7 +274,12 @@ def time_period_desc(seconds: int, case: str = "nf", omit_seconds: bool = True) 
             seconds -= value * count
             plidx = 1 if is_plural(value) else 0
             icename = _TIMEUNIT_NOUNS[unit][plidx][cidx]
-            result.append("{0} {1}".format(value, icename))
+            if num_to_str:
+                # Convert number to spoken text
+                value = number_to_text(
+                    value, case=case, gender="kk" if unit == "d" else "kvk"
+                )
+            result.append(f"{value} {icename}")
 
     return natlang_seq(result)
 
@@ -283,7 +291,11 @@ _METER_NOUN = (
 
 
 def distance_desc(
-    km_dist: float, case: str = "nf", in_metres: float = 1.0, abbr: bool = False
+    km_dist: float,
+    case: str = "nf",
+    in_metres: float = 1.0,
+    abbr: bool = False,
+    num_to_str: bool = False,
 ) -> str:
     """Generate an Icelandic description of distance in km/m w. option to
     specify case, abbreviations, cutoff for returning desc in metres."""
@@ -293,7 +305,10 @@ def distance_desc(
     # E.g. 7,3 kílómetrar
     if km_dist >= in_metres:
         rounded_km = round(km_dist, 1 if km_dist < 10 else 0)
-        dist = iceformat_float(rounded_km)
+        if num_to_str:
+            dist = float_to_text(rounded_km, case=case, gender="kk", comma_null=False)
+        else:
+            dist = iceformat_float(rounded_km)
         plidx = 1 if is_plural(rounded_km) else 0
         unit_long = "kíló" + _METER_NOUN[plidx][cidx]
         unit = "km" if abbr else unit_long
@@ -307,8 +322,10 @@ def distance_desc(
         plidx = 1 if is_plural(dist) else 0
         unit_long = _METER_NOUN[plidx][cidx]
         unit = "m" if abbr else unit_long
+        if num_to_str:
+            dist = number_to_text(dist, case=case, gender="kk")
 
-    return "{0} {1}".format(dist, unit)
+    return f"{dist} {unit}"
 
 
 _KRONA_NOUN = (

--- a/queries/bus.py
+++ b/queries/bus.py
@@ -50,7 +50,7 @@ import query
 from query import AnswerTuple, Query, QueryStateDict, ResponseType, Session
 from tree import Result
 from queries import natlang_seq, cap_first, gen_answer
-from queries.num import numbers_to_neutral
+from queries.num import floats_to_text, numbers_to_text
 from settings import Settings
 from reynir import correct_spaces
 from geo import in_iceland
@@ -635,12 +635,16 @@ def voice_distance(d):
             return "einn kílómetri"
         if km1dec % 10 == 1:
             # 3,1 kílómetri
-            return "{0},{1} kílómetri".format(km1dec // 10, km1dec % 10)
+            return floats_to_text(
+                f"{km1dec // 10},{km1dec % 10} kílómetri", gender="kk", comma_null=False
+            )
         # 5,6 kílómetrar
-        return "{0},{1} kílómetrar".format(km1dec // 10, km1dec % 10)
+        return floats_to_text(
+            f"{km1dec // 10},{km1dec % 10} kílómetrar", gender="kk", comma_null=False
+        )
     # Distance less than 1 km: Round to 10 meters
     m = int(d * 1000 + 5) // 10
-    return "{0}0 metrar".format(m)
+    return numbers_to_text(f"{m}0 metrar", gender="kk")
 
 
 def hms_fmt(hms: Tuple[int, int, int]) -> str:
@@ -784,9 +788,7 @@ def query_arrival_time(query: Query, session: Session, result: Result):
                 + ". Spurðu um eina þeirra."
             )
             voice_answer = (
-                " ".join(
-                    ["Leiðir", numbers_to_neutral(route_seq), "stoppa á", stops_list]
-                )
+                " ".join(["Leiðir", numbers_to_text(route_seq), "stoppa á", stops_list])
                 + ". Spurðu um eina þeirra."
             )
             response = dict(answer=answer)
@@ -800,7 +802,7 @@ def query_arrival_time(query: Query, session: Session, result: Result):
 
     # Prepare results
     bus_name = cap_first(bus_name)
-    va = [bus_name]
+    va = [numbers_to_text(bus_name)]
     a = []
     arrivals = []
     arrivals_dict = {}
@@ -989,7 +991,7 @@ def query_which_route(query: Query, session: Session, result: Result):
             # We convert inflectable numbers to their text equivalents
             # since the speech engine can't be relied upon to get the
             # inflection of numbers right
-            va.append(numbers_to_neutral(rn))
+            va.append(numbers_to_text(rn))
             a.append(rn)
             cnt += 1
         tail = ["stoppar á", to_dative(stop.name)]

--- a/queries/date.py
+++ b/queries/date.py
@@ -31,7 +31,6 @@
 """
 
 # TODO: Special days should be mentioned by name, not date, in voice answers
-# TODO: Fix pronunciation of ordinal day of month (i.e. "29di" vs "29da")
 # TODO: "How many weeks between April 3 and June 16?"
 # TODO: Restore timezone-awareness
 # TODO: "Hvað er mikið eftir af vinnuvikunni", "hvað er langt í helgina"
@@ -71,6 +70,7 @@ from query import Query, QueryStateDict
 from queries import timezone4loc, gen_answer, is_plural, cap_first
 from tree import Result
 from settings import changedlocale
+from queries.num import numbers_to_ordinal, years_to_text, numbers_to_text
 
 
 _DATE_QTYPE = "Date"
@@ -635,84 +635,6 @@ def QDateWinterSolstice(node, params, result):
     result["target"] = None  # To be completed
 
 
-# Day indices in nominative case
-_DAY_INDEX_NOM = {
-    1: "fyrsti",
-    2: "annar",
-    3: "þriðji",
-    4: "fjórði",
-    5: "fimmti",
-    6: "sjötti",
-    7: "sjöundi",
-    8: "áttundi",
-    9: "níundi",
-    10: "tíundi",
-    11: "ellefti",
-    12: "tólfti",
-    13: "þrettándi",
-    14: "fjórtándi",
-    15: "fimmtándi",
-    16: "sextándi",
-    17: "sautjándi",
-    18: "átjándi",
-    19: "nítjándi",
-    20: "tuttugasti",
-    21: "tuttugasti og fyrsti",
-    22: "tuttugasti og annar",
-    23: "tuttugasti og þriðji",
-    24: "tuttugasti og fjórði",
-    25: "tuttugasti og fimmti",
-    26: "tuttugasti og sjötti",
-    27: "tuttugasti og sjöundi",
-    28: "tuttugasti og áttundi",
-    29: "tuttugasti og níundi",
-    30: "þrítugasti",
-    31: "þrítugasti og fyrsti",
-}
-
-
-# Day indices in accusative case
-_DAY_INDEX_ACC = {
-    1: "fyrsta",
-    2: "annan",
-    3: "þriðja",
-    4: "fjórða",
-    5: "fimmta",
-    6: "sjötta",
-    7: "sjöunda",
-    8: "áttunda",
-    9: "níunda",
-    10: "tíunda",
-    11: "ellefta",
-    12: "tólfta",
-    13: "þrettánda",
-    14: "fjórtánda",
-    15: "fimmtánda",
-    16: "sextánda",
-    17: "sautjánda",
-    18: "átjánda",
-    19: "nítjánda",
-    20: "tuttugasta",
-    21: "tuttugasta og fyrsta",
-    22: "tuttugasta og annan",
-    23: "tuttugasta og þriðja",
-    24: "tuttugasta og fjórða",
-    25: "tuttugasta og fimmta",
-    26: "tuttugasta og sjötta",
-    27: "tuttugasta og sjöunda",
-    28: "tuttugasta og áttunda",
-    29: "tuttugasta og níunda",
-    30: "þrítugasta",
-    31: "þrítugasta og fyrsta",
-}
-
-
-# Day indices in dative case
-_DAY_INDEX_DAT = _DAY_INDEX_ACC.copy()
-_DAY_INDEX_DAT[2] = "öðrum"
-_DAY_INDEX_DAT[22] = "tuttugasta og öðrum"
-
-
 def next_weekday(d: datetime, weekday: int) -> datetime:
     """Get the date of the next weekday after a given date.
     0 = Monday, 1 = Tuesday, 2 = Wednesday, etc."""
@@ -779,14 +701,16 @@ def howlong_answ(q: Query, result):
 
     # Check if it's today
     if target.date() == now.date():
+        answer = gen_answer(f"Það er {target.strftime('%-d. %B')} í dag.")
         return q.set_answer(
-            *gen_answer("Það er {0} í dag.".format(target.strftime("%-d. %B")))
+            answer[0], answer[1], numbers_to_ordinal(answer[2], case="nf", gender="kk")
         )
     # Check if it's tomorrow
     # TODO: Maybe return num hours until tomorrow?
     if target.date() == now.date() + timedelta(days=1):
+        answer = gen_answer(f"Það er {target.strftime('%-d. %B')} á morgun.")
         return q.set_answer(
-            *gen_answer("Það er {0} á morgun.".format(target.strftime("%-d. %B")))
+            answer[0], answer[1], numbers_to_ordinal(answer[2], case="nf", gender="kk")
         )
 
     # Returns num days rounded down, so we increment by one.
@@ -809,17 +733,19 @@ def howlong_answ(q: Query, result):
             verb, days, days_desc, passed, tfmt
         )
         # Convert e.g. '25.' to 'tuttugasta og fimmta'
-        voice = re.sub(r" \d+\. ", " " + _DAY_INDEX_DAT[target.day] + " ", voice)
-        answer = "{0} {1}".format(days, days_desc)
+        voice = numbers_to_ordinal(voice, case="þgf", gender="kk")
+        answer = f"{days} {days_desc}."
     # It's in the future
     else:
         voice = "Það {0} {1} {2} þar til {3} gengur í garð.".format(
             verb, days, days_desc, tfmt
         )
         # Convert e.g. '25.' to 'tuttugasti og fimmti'
-        voice = re.sub(r" \d+\. ", " " + _DAY_INDEX_NOM[target.day] + " ", voice)
-        answer = "{0} {1}".format(days, days_desc)
+        voice = numbers_to_ordinal(voice, case="nf", gender="kk")
+        answer = f"{days} {days_desc}."
 
+    # Convert years to spoken text, along with day count
+    voice = numbers_to_text(years_to_text(voice), gender="kk")
     response = dict(answer=answer)
 
     q.set_answer(response, answer, voice)
@@ -835,7 +761,7 @@ def when_answ(q: Query, result):
     answer = voice = cap_first(date_str)
     # Put a spelled-out ordinal number instead of the numeric one,
     # in accusative case
-    voice = re.sub(r"\d+\. ", _DAY_INDEX_ACC[result.target.day] + " ", voice)
+    voice = numbers_to_ordinal(voice, case="þf", gender="kk")
     response = dict(answer=answer)
 
     q.set_key("WhenSpecialDay")
@@ -848,11 +774,12 @@ def currdate_answ(q: Query, result):
     date_str = now.strftime("%A %-d. %B %Y")
     answer = date_str.capitalize()
     response = dict(answer=answer)
-    voice = "Í dag er {0}".format(date_str)
+    voice = f"Í dag er {date_str}"
 
     # Put a spelled-out ordinal number instead of the numeric one
     # to get the grammar right
-    voice = re.sub(r" \d+\. ", " " + _DAY_INDEX_NOM[now.day] + " ", voice)
+    # Also fix year pronounciation
+    voice = years_to_text(numbers_to_ordinal(voice, case="nf", gender="kk"))
 
     q.set_key("CurrentDate")
     q.set_answer(response, answer, voice)
@@ -863,9 +790,16 @@ def days_in_month_answ(q: Query, result):
     ndays = result["days_in_month"]
     t = result["target"]
     mname = t.strftime("%B")
-    answer = "{0} dagar.".format(ndays)
+    answer = f"{ndays} dagar." if is_plural(ndays) else f"{ndays} dagur."
     response = dict(answer=answer)
-    voice = "Það eru {0} dagar í {1} {2}".format(ndays, mname, t.year)
+    voice = (
+        f"Það eru {ndays} dagar í {mname} {t.year}"
+        if is_plural(ndays)
+        else f"Það er {ndays} dagur í {mname} {t.year}"
+    )
+
+    # Convert year and ndays to text for voice
+    voice = numbers_to_text(years_to_text(voice), case="nf", gender="kk")
 
     q.set_key("DaysInMonth")
     q.set_answer(response, answer, voice)
@@ -875,9 +809,9 @@ def year_answ(q: Query, result):
     """ Generate answer to a question of the form "Hvaða ár er núna?" etc. """
     now = datetime.utcnow()
     y = now.year
-    answer = "{0}.".format(y)
+    answer = f"{y}."
     response = dict(answer=answer)
-    voice = "Það er árið {0}.".format(y)
+    voice = years_to_text(f"Það er árið {y}.")
 
     q.set_key("WhichYear")
     q.set_answer(response, answer, voice)
@@ -891,7 +825,7 @@ def leap_answ(q: Query, result):
     verb = "er" if y >= now.year else "var"
     answer = "Árið {0} {1} {2}hlaupár.".format(y, verb, "" if isleap(y) else "ekki ")
     response = dict(answer=answer)
-    voice = answer
+    voice = years_to_text(answer)
 
     q.set_key("IsLeapYear")
     q.set_answer(response, answer, voice)

--- a/queries/distance.py
+++ b/queries/distance.py
@@ -46,7 +46,7 @@ from queries import (
     query_geocode_api_addr,
     query_traveltime_api,
 )
-from queries.num import numbers_to_neutral
+from queries.num import numbers_to_text
 from geo import distance, capitalize_placename
 
 
@@ -275,8 +275,9 @@ def dist_answer_for_loc(matches, query: Query):
     response = dict(answer=answer, distance=km_dist)
 
     loc_nf = capitalize_placename(loc_nf)
-    dist = distance_desc(km_dist, case="þf")
-    voice = "{0} er {1} í burtu".format(numbers_to_neutral(loc_nf), dist)
+    dist = distance_desc(km_dist, case="þf", num_to_str=True)
+    # Turn numbers to neutral in loc_nf for voice
+    voice = f"{numbers_to_text(loc_nf)} er {dist} í burtu"
 
     query.set_key(loc_nf)
 
@@ -327,12 +328,13 @@ def traveltime_answer_for_loc(matches, query: Query):
     # dur_desc = elm["duration"]["text"]  # API duration description
     dur_sec = int(elm["duration"]["value"])
     dur_desc = time_period_desc(dur_sec, case="þf")
+    dur_desc_voice = time_period_desc(dur_sec, case="þf", num_to_str=True)
     dist_desc = elm["distance"]["text"]
 
     # Generate answer
-    answer = "{0} ({1}).".format(dur_desc, dist_desc)
+    answer = f"{dur_desc} ({dist_desc})."
     response = dict(answer=answer, duration=dur_sec)
-    voice = "Að {0} tekur um það bil {1}".format(action_desc, dur_desc)
+    voice = f"Að {action_desc} tekur um það bil {dur_desc_voice}"
 
     # Key is the remote loc in nominative case
     query.set_key(capitalize_placename(loc_nf))

--- a/queries/ja.py
+++ b/queries/ja.py
@@ -36,7 +36,7 @@ from reynir import NounPhrase
 from reynir.bindb import GreynirBin
 
 from . import query_json_api, gen_answer, icequote
-from queries.num import numbers_to_neutral
+from queries.num import numbers_to_text, digits_to_text
 
 from query import AnswerTuple, Query, QueryStateDict
 from tree import Result
@@ -229,7 +229,7 @@ def _answer_phonenum4name_query(q: Query, result: Result) -> AnswerTuple:
     phone_number = phone_number.replace("-", "").replace(" ", "")
     answ = phone_number
     fn = NounPhrase(fname).dative or fname
-    voice = "Síminn hjá {0} er {1}".format(fn, " ".join(list(phone_number)))
+    voice = f"Síminn hjá {fn} er {digits_to_text(phone_number)}"
 
     q.set_context(dict(phone_number=phone_number, name=fname))
     q.set_source(_JA_SOURCE)
@@ -246,7 +246,8 @@ def _answer_name4phonenum_query(q: Query, result: Result) -> AnswerTuple:
     q.set_expires(datetime.utcnow() + timedelta(hours=24))
 
     if not clean_num or len(clean_num) < 3:
-        return gen_answer("{0} er ekki gilt símanúmer".format(num))
+        answer = gen_answer(f"{num} er ekki gilt símanúmer")
+        return (answer[0], answer[1], digits_to_text(answer[2]))
 
     res = query_ja_api(clean_num)
 
@@ -276,7 +277,7 @@ def _answer_name4phonenum_query(q: Query, result: Result) -> AnswerTuple:
     answ = "{0}{1}{2}".format(
         name, " " + occup if occup else "", ", " + full_addr if full_addr else ""
     ).strip()
-    voice = numbers_to_neutral(answ)
+    voice = numbers_to_text(answ)
 
     # Set phone number, name and address as context
     q.set_context(dict(phone_number=clean_num, name=name, address=full_addr))

--- a/queries/petrol.py
+++ b/queries/petrol.py
@@ -24,7 +24,6 @@
 """
 
 # TODO: "Hver er ódýrasta bensínstöðin innan X kílómetra? Innan X kílómetra radíus?" etc.
-# TODO: Laga krónutölur og fjarlægðartölur f. talgervil
 
 from typing import List, Dict, Optional
 
@@ -34,10 +33,15 @@ import random
 
 from geo import distance
 from query import Query
-from queries import query_json_api, gen_answer, distance_desc, krona_desc
-
-from . import AnswerTuple, LatLonTuple
-
+from queries import (
+    query_json_api,
+    gen_answer,
+    distance_desc,
+    krona_desc,
+    AnswerTuple,
+    LatLonTuple,
+)
+from queries.num import numbers_to_text, floats_to_text
 
 _PETROL_QTYPE = "Petrol"
 
@@ -330,7 +334,7 @@ def _answ_for_petrol_query(q: Query, result) -> AnswerTuple:
             "Þar kostar bensínlítrinn {4} og dísel-lítrinn {5}."
         )
         dist_nf = distance_desc(station["distance"], case="nf")
-        dist_þf = distance_desc(station["distance"], case="þf")
+        dist_ef = distance_desc(station["distance"], case="ef", num_to_str=True)
         answer = answ_fmt.format(
             station["company"], station["name"], dist_nf, bensin_kr_desc, diesel_kr_desc
         )
@@ -338,9 +342,9 @@ def _answ_for_petrol_query(q: Query, result) -> AnswerTuple:
             desc,
             station["company"],
             station["name"],
-            dist_þf,
-            bensin_kr_desc,
-            diesel_kr_desc,
+            dist_ef,
+            floats_to_text(bensin_kr_desc.replace(".", ""), gender="kvk"),
+            floats_to_text(diesel_kr_desc.replace(".", ""), gender="kvk"),
         )
     else:
         answ_fmt = "{0} {1} (bensínverð {2}, díselverð {3})"
@@ -349,7 +353,11 @@ def _answ_for_petrol_query(q: Query, result) -> AnswerTuple:
             station["company"], station["name"], bensin_kr_desc, diesel_kr_desc
         )
         voice = voice_fmt.format(
-            desc, station["company"], station["name"], bensin_kr_desc, diesel_kr_desc
+            desc,
+            station["company"],
+            station["name"],
+            floats_to_text(bensin_kr_desc.replace(".", ""), gender="kvk"),
+            floats_to_text(diesel_kr_desc.replace(".", ""), gender="kvk"),
         )
 
     response = dict(answer=answer)

--- a/queries/places.py
+++ b/queries/places.py
@@ -44,7 +44,7 @@ from queries import (
     query_place_details,
     icequote,
 )
-from queries.num import numbers_to_neutral
+from queries.num import numbers_to_text
 from tree import Result
 
 from . import LatLonTuple, AnswerTuple
@@ -266,7 +266,7 @@ def answ_address(placename: str, loc: LatLonTuple, qtype: str) -> AnswerTuple:
 
     # Create answer
     answer = final_addr
-    voice = "{0} er {1} {2}".format(placename, prep, numbers_to_neutral(final_addr))
+    voice = f"{placename} er {prep} {numbers_to_text(final_addr)}"
     response = dict(answer=answer)
 
     return response, answer, voice

--- a/queries/random.py
+++ b/queries/random.py
@@ -31,6 +31,7 @@ import random
 from query import Query, QueryStateDict
 from queries import gen_answer
 from queries.arithmetic import add_num, terminal_num
+from queries.num import number_to_text
 from tree import Result
 
 
@@ -168,9 +169,11 @@ def gen_random_answer(q: Query, result):
     answer = str(random.randint(num1, num2))
     response = dict(answer=answer)
     if result.action == "dieroll":
-        voice_answer = "Talan {0} kom upp á teningnum".format(answer)
+        voice_answer = (
+            f"Talan {number_to_text(answer, gender='kk')} kom upp á teningnum"
+        )
     else:
-        voice_answer = "Ég vel töluna {0}".format(answer)
+        voice_answer = f"Ég vel töluna {number_to_text(answer, gender='kk')}"
 
     return response, answer, voice_answer
 

--- a/queries/sunpos.py
+++ b/queries/sunpos.py
@@ -54,7 +54,7 @@ from geo import (
     ICE_PLACENAME_BLACKLIST,
 )
 from iceaddr import placename_lookup
-
+from queries.num import numbers_to_ordinal, floats_to_text
 
 # Indicate that this module wants to handle parse trees for queries,
 # as opposed to simple literal text strings
@@ -534,7 +534,6 @@ def _answer_city_solar_data(
 
         degrees = str(data[city][closest_date][sun_pos]).replace(".", ",")
         answer = f"Sólarhæð um hádegi {when} {is_will_was} um {degrees} {'gráður' if is_plural(degrees) else 'gráða'}."
-        voice = answer
 
     else:
         time: Optional[datetime.time] = cast(
@@ -563,32 +562,35 @@ def _answer_city_solar_data(
 
             if sun_pos == _SOLAR_POSITIONS.SÓLRIS:
                 if in_past:
-                    voice = answer = f"Sólin reis um klukkan {time_str} {when}."
+                    answer = f"Sólin reis um klukkan {time_str} {when}."
                 else:
-                    voice = answer = f"Sólin rís um klukkan {time_str} {when}."
+                    answer = f"Sólin rís um klukkan {time_str} {when}."
 
             elif sun_pos == _SOLAR_POSITIONS.SÓLARLAG:
                 if in_past:
-                    voice = answer = f"Sólin settist um klukkan {time_str} {when}."
+                    answer = f"Sólin settist um klukkan {time_str} {when}."
                 else:
-                    voice = answer = f"Sólin sest um klukkan {time_str} {when}."
+                    answer = f"Sólin sest um klukkan {time_str} {when}."
 
             else:
-                voice = answer = format_ans.format(
+                answer = format_ans.format(
                     _SOLAR_ENUM_TO_WORD[sun_pos], time_str, when
                 )
 
         else:
             format_ans = "Það varð ekki {0} {1}."
 
-            voice = answer = format_ans.format(
+            answer = format_ans.format(
                 _SOLAR_ENUM_TO_WORD[sun_pos].lower(), when
             )
 
     if not in_past:
-        voice = answer = answer.replace("varð", "verður").replace("var", "verður")
+        answer = answer.replace("varð", "verður").replace("var", "verður")
 
-    # TODO: voicify string
+    # Convert date ordinals to text for voice
+    voice = numbers_to_ordinal(answer, case="þf", gender="kk")
+    # Convert degrees to text for voice when asking about height of sun
+    voice = floats_to_text(voice, gender="kvk")
     return {"answer": answer, "voice": voice}, answer, voice
 
 

--- a/queries/userinfo.py
+++ b/queries/userinfo.py
@@ -34,7 +34,7 @@ from reynir.bindb import GreynirBin
 from geo import icelandic_addr_info, iceprep_for_placename, iceprep_for_street
 from query import ClientDataDict, Query
 from . import gen_answer
-from queries.num import numbers_to_neutral
+from queries.num import numbers_to_text
 
 
 _USERINFO_QTYPE = "UserInfo"
@@ -194,7 +194,7 @@ def _addr2str(addr: Dict[str, str], case: str = "nf") -> str:
                 astr = n.dative or astr
         except Exception:
             pass
-    return numbers_to_neutral(astr)
+    return numbers_to_text(astr)
 
 
 _WHATS_MY_ADDR = frozenset(

--- a/queries/userloc.py
+++ b/queries/userloc.py
@@ -35,7 +35,7 @@ from queries import (
     nom2dat,
     cap_first,
 )
-from queries.num import numbers_to_neutral
+from queries.num import numbers_to_text
 from tree import Result
 from iceaddr import iceaddr_lookup, postcodes  # type: ignore
 from geo import iceprep_for_placename, iceprep_for_street
@@ -212,9 +212,11 @@ def _addr4voice(addr: str) -> Optional[str]:
     """ Prepare an address string for voice synthesizer. """
     # E.g. "Fiskislóð 5-9" becomes "Fiskislóð 5 til 9"
     s = re.sub(r"(\d+)\-(\d+)", r"\1 til \2", addr)
+    # E.g. "Fiskislóð 31d" becomes "Fiskislóð 31 d"
+    s = re.sub(r"(\d+)([a-zA-Z])", r"\1 \2", s)
     # Convert numbers to neutral gender:
     # 'Fiskislóð 2 til 4' -> 'Fiskislóð tvö til fjögur'
-    return numbers_to_neutral(s) if s else None
+    return numbers_to_text(s) if s else None
 
 
 def answer_for_location(loc: Tuple):

--- a/queries/yulelads.py
+++ b/queries/yulelads.py
@@ -470,11 +470,7 @@ def sentence(state: QueryStateDict, result: Result) -> None:
                 answer = voice_answer = "Þetta er ekki gildur mánaðardagur."
             else:
                 # TODO: Fix, always replies "desember" even during other months
-                answer = (
-                    voice_answer
-                ) = "Enginn jólasveinn kemur til byggða þann {0} desember.".format(
-                    _DATE_TO_ORDINAL[result.lad_date]
-                )
+                answer = f"Enginn jólasveinn kemur til byggða þann {result.lad_date}. desember."
         else:
             yule_lad = result.yule_lad
             answer = (

--- a/queries/yulelads.py
+++ b/queries/yulelads.py
@@ -30,6 +30,7 @@ from datetime import datetime
 
 from query import Query, QueryStateDict
 from tree import Result
+from queries.num import numbers_to_ordinal
 
 
 def help_text(lemma: str) -> str:
@@ -120,10 +121,6 @@ _ORDINAL_TO_DATE = {
     "þrítugasta og fyrsta": 31,
 }
 
-_DATE_TO_ORDINAL = {v: k for k, v in _ORDINAL_TO_DATE.items()}
-# Date in genitive case - turns out only the 22nd is different
-_DATE_TO_ORDINAL_GEN = _DATE_TO_ORDINAL.copy()
-_DATE_TO_ORDINAL_GEN[22] = "tuttugasta og annars"
 
 _TWENTY_PART = {"fyrsta": 1, "annan": 2, "þriðja": 3, "fjórða": 4}
 
@@ -464,9 +461,7 @@ def sentence(state: QueryStateDict, result: Result) -> None:
     if result.qtype == "YuleDate":
         # 'Hvenær kemur [jólasveinn X]'
         yule_lad = result.yule_lad
-        answer = voice_answer = "{0} kemur til byggða aðfaranótt {1} desember.".format(
-            yule_lad, _DATE_TO_ORDINAL_GEN[result.lad_date]
-        )
+        answer = f"{yule_lad} kemur til byggða aðfaranótt {result.lad_date}. desember."
     elif result.qtype == "YuleLad":
         # 'Hvaða jólasveinn kemur til byggða [á degi x]'
         lad_date = result.lad_date
@@ -483,12 +478,11 @@ def sentence(state: QueryStateDict, result: Result) -> None:
         else:
             yule_lad = result.yule_lad
             answer = (
-                voice_answer
-            ) = "{0} kemur til byggða aðfaranótt {1} desember.".format(
-                yule_lad, _DATE_TO_ORDINAL_GEN[result.lad_date]
+                f"{yule_lad} kemur til byggða aðfaranótt {result.lad_date}. desember."
             )
         q.lowercase_beautified_query()
 
+    voice_answer = numbers_to_ordinal(answer, case="ef", gender="kk")
     response = dict(answer=answer)
     # !!! TODO
     # q.set_context({"date": xxx})

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -214,7 +214,10 @@ def test_bus(client: FlaskClient):
         client, {"q": "hvaða stoppistöð er næst mér", "voice": True}, "NearestStop"
     )
     assert json["answer"] == "Fiskislóð"
-    assert json["voice"] == "Næsta stoppistöð er Fiskislóð; þangað eru 310 metrar."
+    assert (
+        json["voice"]
+        == "Næsta stoppistöð er Fiskislóð; þangað eru þrjú hundruð og tíu metrar."
+    )
 
     json = qmcall(
         client,
@@ -339,16 +342,23 @@ def test_date(client: FlaskClient):
     json = qmcall(client, {"q": "er 2020 hlaupár?"}, "Date")
     assert "var hlaupár" in json["answer"]
 
-    json = qmcall(client, {"q": "var árið 1999 hlaupár?"}, "Date")
+    json = qmcall(client, {"q": "var árið 1999 hlaupár?", "voice": True}, "Date")
     assert "ekki hlaupár" in json["answer"]
+    assert "nítján hundruð níutíu og níu" in json["voice"]
 
-    json = qmcall(client, {"q": "hvað eru margir dagar í desember"}, "Date")
+    json = qmcall(
+        client, {"q": "hvað eru margir dagar í desember", "voice": True}, "Date"
+    )
     assert json["answer"].startswith("31")
     assert "dag" in json["answer"]
+    assert "þrjátíu og einn" in json["voice"]
 
-    json = qmcall(client, {"q": "hvað eru margir dagar í febrúar 2024"}, "Date")
+    json = qmcall(
+        client, {"q": "hvað eru margir dagar í febrúar 2024", "voice": True}, "Date"
+    )
     assert json["answer"].startswith("29")
     assert "dag" in json["answer"]
+    assert "tuttugu og níu" in json["voice"]
 
     json = qmcall(client, {"q": "Hvað er langt fram að verslunarmannahelgi"}, "Date")
     assert re.search(r"^\d+", json["answer"])
@@ -356,8 +366,9 @@ def test_date(client: FlaskClient):
     # json = qmcall(client, {"q": "hvað er langt liðið frá uppstigningardegi"}, "Date")
     # assert re.search(r"^\d+", json["answer"])
 
-    json = qmcall(client, {"q": "hvenær eru jólin"}, "Date")
+    json = qmcall(client, {"q": "hvenær eru jólin", "voice": True}, "Date")
     assert re.search(r"25", json["answer"]) is not None
+    assert "tuttugasta og fimmta" in json["voice"]
 
 
 def test_dictionary(client: FlaskClient):
@@ -382,7 +393,10 @@ def test_distance(client: FlaskClient):
         client, {"q": "hvað er ég langt frá perlunni", "voice": True}, "Distance"
     )
     assert json["answer"].startswith("3,5 km")
-    assert json["voice"].startswith("Perlan er ")
+    assert (
+        json["voice"].startswith("Perlan er ")
+        and "þrjá komma fimm kílómetra" in json["voice"]
+    )
     assert json["source"] == "Google Maps"
 
     json = qmcall(
@@ -408,12 +422,12 @@ def test_distance(client: FlaskClient):
     assert json["answer"].endswith("(389 km).")
 
 
-def _test_flights(client: FlaskClient):
+def test_flights(client: FlaskClient):
     """ Flights module """
     departure_pattern = r"^Flug \w*? til .*? flýgur frá \w*? \d+\. \w*? klukkan \d\d\:\d\d að staðartíma.$"
     arrival_pattern = r"^Flug \w*? frá .*? lendir [í|á] \w*? \d+\. \w*? klukkan \d\d\:\d\d að staðartíma.$"
     no_matching_flight_pattern = (
-        r"Ekkert flug fannst (frá .*? )?(til .*? )?næstu \d+ daga."
+        r"Ekkert flug fannst (frá .*? )?(til .*? )?næstu \d+ sólarhringa."
     )
 
     json = qmcall(
@@ -562,8 +576,7 @@ def test_ja(client: FlaskClient):
         "PhoneNum4Name",
     )
     assert "6992422" in json["answer"]
-    # TODO
-    # assert "sex níu níu" in json["voice"]
+    assert "sex níu níu tveir fjórir tveir tveir" in json["voice"]
 
     json = qmcall(
         client,
@@ -574,8 +587,7 @@ def test_ja(client: FlaskClient):
         "PhoneNum4Name",
     )
     assert "6992422" in json["answer"]
-    # TODO
-    # assert "sex níu níu" in json["voice"]
+    assert "sex níu níu tveir fjórir tveir tveir" in json["voice"]
 
     json = qmcall(
         client,
@@ -589,10 +601,14 @@ def test_ja(client: FlaskClient):
 
     json = qmcall(
         client,
-        {"q": "hver er síminn hjá Vilhjálmi Þorsteinssyni hugbúnaðarhönnuði"},
+        {
+            "q": "hver er síminn hjá Vilhjálmi Þorsteinssyni hugbúnaðarhönnuði",
+            "voice": True,
+        },
         "PhoneNum4Name",
     )
     assert "8201020" in json["answer"]
+    assert "átta tveir núll einn núll tveir núll" in json["voice"]
 
 
 def test_news(client: FlaskClient):
@@ -746,21 +762,34 @@ def test_sunpos(client: FlaskClient):
     assert re.match(
         fr"^Sólin (sest|settist) um klukkan \d?\d:\d\d {timings}\.$", json["answer"]
     )
-    json = qmcall(client, {"q": "hver er sólarhæð í Reykjavík í dag?"}, "SunPosition")
+    json = qmcall(
+        client,
+        {"q": "hver er sólarhæð í Reykjavík í dag?", "voice": True},
+        "SunPosition",
+    )
     assert re.match(
         r"^Sólarhæð um hádegi í dag (er|var|verður) um \d+,\d+ gráð(a|ur)\.$",
         json["answer"],
     )
-    json = qmcall(client, {"q": "hver er hæð sólar í Reykjavík í dag?"}, "SunPosition")
+    assert not re.findall(r"\d+", json["voice"])
+    json = qmcall(
+        client,
+        {"q": "hver er hæð sólar í Reykjavík í dag?", "voice": True},
+        "SunPosition",
+    )
     assert re.match(
         r"^Sólarhæð um hádegi í dag (er|var|verður) um \d+,\d+ gráð(a|ur)\.$",
         json["answer"],
     )
-    json = qmcall(client, {"q": "hver er hæð sólarinnar í dag?"}, "SunPosition")
+    assert not re.findall(r"\d+", json["voice"])
+    json = qmcall(
+        client, {"q": "hver er hæð sólarinnar í dag?", "voice": True}, "SunPosition"
+    )
     assert re.match(
         r"^Sólarhæð um hádegi í dag (er|var|verður) um \d+,\d+ gráð(a|ur)\.$",
         json["answer"],
     )
+    assert not re.findall(r"\d+", json["voice"])
     # json = qmcall(client, {"q": "hver er hæð sólar í dag?"}, "SunPosition")
     # assert re.match(
     #     r"^Sólarhæð um hádegi í dag (er|var|verður) um \d+,\d+ gráð(a|ur)\.$",
@@ -785,7 +814,9 @@ def test_sunpos(client: FlaskClient):
     )
     assert re.match(
         r"^Það verður ekki birting á morgun\.$", json["answer"]
-    ) or re.match(r"^Birting verður um klukkan \d?\d:\d\d (á morgun|í nótt)\.$", json["answer"])
+    ) or re.match(
+        r"^Birting verður um klukkan \d?\d:\d\d (á morgun|í nótt)\.$", json["answer"]
+    )
     json = qmcall(client, {"q": "hvenær er hádegi á morgun á Ísafirði?"}, "SunPosition")
     assert re.match(r"^Hádegi verður um klukkan \d?\d:\d\d á morgun\.$", json["answer"])
     json = qmcall(
@@ -1049,7 +1080,6 @@ def test_query_utility_functions():
         timezone4loc,
         # parse_num,
     )
-    from queries.num import numbers_to_neutral
 
     assert natlang_seq(["Jón", "Gunna"]) == "Jón og Gunna"
     assert natlang_seq(["Jón", "Gunna", "Siggi"]) == "Jón, Gunna og Siggi"
@@ -1063,9 +1093,6 @@ def test_query_utility_functions():
 
     # assert parse_num("11") == 11
     # assert parse_num("17,33") == 17.33
-
-    assert numbers_to_neutral("Öldugötu 4") == "Öldugötu fjögur"
-    assert numbers_to_neutral("Fiskislóð 31") == "Fiskislóð þrjátíu og eitt"
 
     assert is_plural(22)
     assert is_plural(11)
@@ -1103,6 +1130,24 @@ def test_query_utility_functions():
         time_period_desc(121, omit_seconds=False, case="þgf")
         == "2 mínútum og 1 sekúndu"
     )
+    assert time_period_desc(3751, num_to_str=True) == "ein klukkustund og þrjár mínútur"
+    assert (
+        time_period_desc(3751, omit_seconds=False, num_to_str=True)
+        == "ein klukkustund, tvær mínútur og þrjátíu og ein sekúnda"
+    )
+    assert time_period_desc(601, num_to_str=True) == "tíu mínútur"
+    assert (
+        time_period_desc(86401, omit_seconds=False, case="ef", num_to_str=True)
+        == "eins dags og einnar sekúndu"
+    )
+    assert (
+        time_period_desc(172802, omit_seconds=False, case="þf", num_to_str=True)
+        == "tvo daga og tvær sekúndur"
+    )
+    assert (
+        time_period_desc(121, omit_seconds=False, case="þgf", num_to_str=True)
+        == "tveimur mínútum og einni sekúndu"
+    )
 
     assert distance_desc(1.1) == "1,1 kílómetri"
     assert distance_desc(1.2) == "1,2 kílómetrar"
@@ -1110,6 +1155,22 @@ def test_query_utility_functions():
     assert distance_desc(0.021) == "20 metrar"
     assert distance_desc(41, case="þf") == "41 kílómetra"
     assert distance_desc(0.215, case="þgf") == "220 metrum"
+    assert distance_desc(1.1, num_to_str=True) == "einn komma einn kílómetri"
+    assert distance_desc(1.2, num_to_str=True) == "einn komma tveir kílómetrar"
+    assert (
+        distance_desc(1.2, case="þgf", num_to_str=True)
+        == "einum komma tveimur kílómetrum"
+    )
+    assert (
+        distance_desc(1.2, case="ef", num_to_str=True) == "eins komma tveggja kílómetra"
+    )
+    assert distance_desc(0.7, num_to_str=True) == "sjö hundruð metrar"
+    assert distance_desc(0.021, num_to_str=True) == "tuttugu metrar"
+    assert distance_desc(41, case="þf", num_to_str=True) == "fjörutíu og einn kílómetra"
+    assert (
+        distance_desc(0.215, case="þgf", num_to_str=True)
+        == "tvö hundruð og tuttugu metrum"
+    )
 
     assert krona_desc(361) == "361 króna"
     assert krona_desc(28) == "28 krónur"
@@ -1138,7 +1199,7 @@ def test_query_utility_functions():
 
 def test_numbers():
     """ Test number handling functionality in queries """
-    from queries.num import number_to_neutral, number_to_text, numbers_to_neutral
+    from queries.num import number_to_neutral, number_to_text, numbers_to_text
 
     assert number_to_neutral(2) == "tvö"
     assert number_to_neutral(1100) == "eitt þúsund og eitt hundrað"
@@ -1148,185 +1209,193 @@ def test_numbers():
     )
     assert number_to_neutral(241000000000) == "tvö hundruð fjörutíu og einn milljarður"
     assert number_to_neutral(100000000) == "eitt hundrað milljónir"
+    assert number_to_neutral(1001000000) == "einn milljarður og ein milljón"
+    assert number_to_neutral(1002000000) == "einn milljarður og tvær milljónir"
     assert number_to_neutral(200000000000) == "tvö hundruð milljarðar"
     assert (
         number_to_neutral(10000000000000000000000000000000000000000000000000000000)
         == "tíu milljónir oktilljóna"
     )
-
-    assert number_to_text(101, "kk") == "eitt hundrað og einn"
-    assert number_to_text(-102, "kvk") == "mínus eitt hundrað og tvær"
-    assert number_to_text(5, "kk") == "fimm"
-    assert number_to_text(10001, "kvk") == "tíu þúsund og ein"
-    assert number_to_text(400567, "hk") == number_to_neutral(400567)
     assert (
-        number_to_text(-11220024, "kvk")
+        number_to_neutral(1000000000000000000000000000000000000001000000000)
+        == "ein oktilljón og einn milljarður"
+    )
+    assert (
+        number_to_neutral(1000000000000000000000000000000000000003000000000)
+        == "ein oktilljón og þrír milljarðar"
+    )
+    assert number_to_neutral(3000400000) == "þrír milljarðar og fjögur hundruð þúsund"
+    assert (
+        number_to_neutral(2000000000000000000000000000000000100000000000000)
+        == "tvær oktilljónir og eitt hundrað billjónir"
+    )
+
+    assert number_to_text(101, gender="kk") == "hundrað og einn"
+    assert number_to_text(-102, gender="kvk") == "mínus hundrað og tvær"
+    assert (
+        number_to_text(-102, gender="kvk", eitt_hundrad=True)
+        == "mínus eitt hundrað og tvær"
+    )
+    assert number_to_text(5, gender="kk") == "fimm"
+    assert number_to_text(10001, gender="kvk") == "tíu þúsund og ein"
+    assert number_to_text(400567, gender="hk") == number_to_neutral(400567)
+    assert (
+        number_to_text(-11220024, gender="kvk")
         == "mínus ellefu milljónir tvö hundruð og tuttugu þúsund tuttugu og fjórar"
     )
 
-    assert numbers_to_neutral("Baugatangi 1, Reykjavík") == "Baugatangi eitt, Reykjavík"
-    assert numbers_to_neutral("Baugatangi 2, Reykjavík") == "Baugatangi tvö, Reykjavík"
-    assert numbers_to_neutral("Baugatangi 3, Reykjavík") == "Baugatangi þrjú, Reykjavík"
+    assert numbers_to_text("Baugatangi 1, Reykjavík") == "Baugatangi eitt, Reykjavík"
+    assert numbers_to_text("Baugatangi 2, Reykjavík") == "Baugatangi tvö, Reykjavík"
+    assert numbers_to_text("Baugatangi 3, Reykjavík") == "Baugatangi þrjú, Reykjavík"
+    assert numbers_to_text("Baugatangi 4, Reykjavík") == "Baugatangi fjögur, Reykjavík"
+    assert numbers_to_text("Baugatangi 5, Reykjavík") == "Baugatangi fimm, Reykjavík"
+    assert numbers_to_text("Baugatangi 10, Reykjavík") == "Baugatangi tíu, Reykjavík"
+    assert numbers_to_text("Baugatangi 11, Reykjavík") == "Baugatangi ellefu, Reykjavík"
+    assert numbers_to_text("Baugatangi 12, Reykjavík") == "Baugatangi tólf, Reykjavík"
     assert (
-        numbers_to_neutral("Baugatangi 4, Reykjavík") == "Baugatangi fjögur, Reykjavík"
+        numbers_to_text("Baugatangi 13, Reykjavík") == "Baugatangi þrettán, Reykjavík"
     )
-    assert numbers_to_neutral("Baugatangi 5, Reykjavík") == "Baugatangi 5, Reykjavík"
-    assert numbers_to_neutral("Baugatangi 10, Reykjavík") == "Baugatangi 10, Reykjavík"
-    assert numbers_to_neutral("Baugatangi 11, Reykjavík") == "Baugatangi 11, Reykjavík"
-    assert numbers_to_neutral("Baugatangi 12, Reykjavík") == "Baugatangi 12, Reykjavík"
-    assert numbers_to_neutral("Baugatangi 13, Reykjavík") == "Baugatangi 13, Reykjavík"
-    assert numbers_to_neutral("Baugatangi 14, Reykjavík") == "Baugatangi 14, Reykjavík"
-    assert numbers_to_neutral("Baugatangi 15, Reykjavík") == "Baugatangi 15, Reykjavík"
-    assert numbers_to_neutral("Baugatangi 20, Reykjavík") == "Baugatangi 20, Reykjavík"
     assert (
-        numbers_to_neutral("Baugatangi 21, Reykjavík")
+        numbers_to_text("Baugatangi 14, Reykjavík") == "Baugatangi fjórtán, Reykjavík"
+    )
+    assert (
+        numbers_to_text("Baugatangi 15, Reykjavík") == "Baugatangi fimmtán, Reykjavík"
+    )
+    assert (
+        numbers_to_text("Baugatangi 20, Reykjavík") == "Baugatangi tuttugu, Reykjavík"
+    )
+    assert (
+        numbers_to_text("Baugatangi 21, Reykjavík")
         == "Baugatangi tuttugu og eitt, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 22, Reykjavík")
+        numbers_to_text("Baugatangi 22, Reykjavík")
         == "Baugatangi tuttugu og tvö, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 23, Reykjavík")
+        numbers_to_text("Baugatangi 23, Reykjavík")
         == "Baugatangi tuttugu og þrjú, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 24, Reykjavík")
+        numbers_to_text("Baugatangi 24, Reykjavík")
         == "Baugatangi tuttugu og fjögur, Reykjavík"
     )
-    assert numbers_to_neutral("Baugatangi 25, Reykjavík") == "Baugatangi 25, Reykjavík"
     assert (
-        numbers_to_neutral("Baugatangi 100, Reykjavík") == "Baugatangi 100, Reykjavík"
+        numbers_to_text("Baugatangi 25, Reykjavík")
+        == "Baugatangi tuttugu og fimm, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 101, Reykjavík")
+        numbers_to_text("Baugatangi 100, Reykjavík") == "Baugatangi hundrað, Reykjavík"
+    )
+    assert (
+        numbers_to_text("Baugatangi 101, Reykjavík")
         == "Baugatangi hundrað og eitt, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 102, Reykjavík")
+        numbers_to_text("Baugatangi 102, Reykjavík")
         == "Baugatangi hundrað og tvö, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 103, Reykjavík")
+        numbers_to_text("Baugatangi 103, Reykjavík")
         == "Baugatangi hundrað og þrjú, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 104, Reykjavík")
+        numbers_to_text("Baugatangi 104, Reykjavík")
         == "Baugatangi hundrað og fjögur, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 105, Reykjavík") == "Baugatangi 105, Reykjavík"
+        numbers_to_text("Baugatangi 105, Reykjavík")
+        == "Baugatangi hundrað og fimm, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 111, Reykjavík") == "Baugatangi 111, Reykjavík"
+        numbers_to_text("Baugatangi 111, Reykjavík")
+        == "Baugatangi hundrað og ellefu, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 112, Reykjavík") == "Baugatangi 112, Reykjavík"
+        numbers_to_text("Baugatangi 112, Reykjavík")
+        == "Baugatangi hundrað og tólf, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 113, Reykjavík") == "Baugatangi 113, Reykjavík"
+        numbers_to_text("Baugatangi 113, Reykjavík")
+        == "Baugatangi hundrað og þrettán, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 114, Reykjavík") == "Baugatangi 114, Reykjavík"
+        numbers_to_text("Baugatangi 114, Reykjavík")
+        == "Baugatangi hundrað og fjórtán, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 115, Reykjavík") == "Baugatangi 115, Reykjavík"
+        numbers_to_text("Baugatangi 115, Reykjavík")
+        == "Baugatangi hundrað og fimmtán, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 121, Reykjavík")
+        numbers_to_text("Baugatangi 121, Reykjavík")
         == "Baugatangi hundrað tuttugu og eitt, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 174, Reykjavík")
+        numbers_to_text("Baugatangi 174, Reykjavík")
         == "Baugatangi hundrað sjötíu og fjögur, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 200, Reykjavík") == "Baugatangi 200, Reykjavík"
+        numbers_to_text("Baugatangi 200, Reykjavík")
+        == "Baugatangi tvö hundruð, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 201, Reykjavík")
+        numbers_to_text("Baugatangi 201, Reykjavík")
         == "Baugatangi tvö hundruð og eitt, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 202, Reykjavík")
+        numbers_to_text("Baugatangi 202, Reykjavík")
         == "Baugatangi tvö hundruð og tvö, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 203, Reykjavík")
+        numbers_to_text("Baugatangi 203, Reykjavík")
         == "Baugatangi tvö hundruð og þrjú, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 204, Reykjavík")
+        numbers_to_text("Baugatangi 204, Reykjavík")
         == "Baugatangi tvö hundruð og fjögur, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 205, Reykjavík") == "Baugatangi 205, Reykjavík"
+        numbers_to_text("Baugatangi 205, Reykjavík")
+        == "Baugatangi tvö hundruð og fimm, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 211, Reykjavík") == "Baugatangi 211, Reykjavík"
+        numbers_to_text("Baugatangi 211, Reykjavík")
+        == "Baugatangi tvö hundruð og ellefu, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 212, Reykjavík") == "Baugatangi 212, Reykjavík"
+        numbers_to_text("Baugatangi 212, Reykjavík")
+        == "Baugatangi tvö hundruð og tólf, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 213, Reykjavík") == "Baugatangi 213, Reykjavík"
+        numbers_to_text("Baugatangi 213, Reykjavík")
+        == "Baugatangi tvö hundruð og þrettán, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 214, Reykjavík") == "Baugatangi 214, Reykjavík"
+        numbers_to_text("Baugatangi 214, Reykjavík")
+        == "Baugatangi tvö hundruð og fjórtán, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 215, Reykjavík") == "Baugatangi 215, Reykjavík"
+        numbers_to_text("Baugatangi 215, Reykjavík")
+        == "Baugatangi tvö hundruð og fimmtán, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 700, Reykjavík") == "Baugatangi 700, Reykjavík"
+        numbers_to_text("Baugatangi 700, Reykjavík")
+        == "Baugatangi sjö hundruð, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 701, Reykjavík")
-        == "Baugatangi sjö hundruð og eitt, Reykjavík"
-    )
-    assert (
-        numbers_to_neutral("Baugatangi 702, Reykjavík")
-        == "Baugatangi sjö hundruð og tvö, Reykjavík"
-    )
-    assert (
-        numbers_to_neutral("Baugatangi 703, Reykjavík")
-        == "Baugatangi sjö hundruð og þrjú, Reykjavík"
-    )
-    assert (
-        numbers_to_neutral("Baugatangi 704, Reykjavík")
-        == "Baugatangi sjö hundruð og fjögur, Reykjavík"
-    )
-    assert (
-        numbers_to_neutral("Baugatangi 705, Reykjavík") == "Baugatangi 705, Reykjavík"
-    )
-    assert (
-        numbers_to_neutral("Baugatangi 711, Reykjavík") == "Baugatangi 711, Reykjavík"
-    )
-    assert (
-        numbers_to_neutral("Baugatangi 712, Reykjavík") == "Baugatangi 712, Reykjavík"
-    )
-    assert (
-        numbers_to_neutral("Baugatangi 713, Reykjavík") == "Baugatangi 713, Reykjavík"
-    )
-    assert (
-        numbers_to_neutral("Baugatangi 714, Reykjavík") == "Baugatangi 714, Reykjavík"
-    )
-    assert (
-        numbers_to_neutral("Baugatangi 715, Reykjavík") == "Baugatangi 715, Reykjavík"
-    )
-    assert (
-        numbers_to_neutral("Baugatangi 1-4, Reykjavík")
+        numbers_to_text("Baugatangi 1-4, Reykjavík")
         == "Baugatangi eitt-fjögur, Reykjavík"
     )
     assert (
-        numbers_to_neutral("Baugatangi 1-17, Reykjavík")
-        == "Baugatangi eitt-17, Reykjavík"
+        numbers_to_text("Baugatangi 1-17, Reykjavík")
+        == "Baugatangi eitt-sautján, Reykjavík"
     )
 
 
 def test_years():
-    """Test number to written year conversion."""
-    from queries.num import year_to_text
+    """ Test number to written year conversion. """
+    from queries.num import year_to_text, years_to_text
 
     assert year_to_text(1999) == "nítján hundruð níutíu og níu"
     assert year_to_text(2004) == "tvö þúsund og fjögur"
@@ -1335,30 +1404,87 @@ def test_years():
     assert year_to_text(57, after_christ=True) == "fimmtíu og sjö eftir Krist"
     assert year_to_text(2401) == "tvö þúsund fjögur hundruð og eitt"
 
+    assert (
+        years_to_text("Ég fæddist 1994") == "Ég fæddist nítján hundruð níutíu og fjögur"
+    )
+    assert (
+        years_to_text("Árið 1461 var borgin Sarajevo stofnuð")
+        == "Árið fjórtán hundruð sextíu og eitt var borgin Sarajevo stofnuð"
+    )
+    assert (
+        years_to_text("17. júlí 1210 lést Sverker II")
+        == "17. júlí tólf hundruð og tíu lést Sverker II"
+    )
+    assert (
+        years_to_text("2021, 2007 og 1999")
+        == "tvö þúsund tuttugu og eitt, tvö þúsund og sjö og nítján hundruð níutíu og níu"
+    )
+
 
 def test_ordinals():
-    """Test number to written ordinal conversion."""
-    from queries.num import number_to_ordinal
+    """ Test number to written ordinal conversion. """
+    from queries.num import number_to_ordinal, numbers_to_ordinal
 
     assert number_to_ordinal(0) == "núllti"
-    assert number_to_ordinal(22, "þgf", "kvk") == "tuttugustu og annarri"
+    assert number_to_ordinal(22, case="þgf", gender="kvk") == "tuttugustu og annarri"
     assert number_to_ordinal(302, gender="kvk") == "þrjú hundraðasta og önnur"
-    assert number_to_ordinal(302, "þgf", "hk") == "þrjú hundraðasta og öðru"
+    assert number_to_ordinal(302, case="þgf", gender="hk") == "þrjú hundraðasta og öðru"
     assert (
-        number_to_ordinal(10202, "þgf", "hk", "ft")
+        number_to_ordinal(10202, case="þgf", gender="hk", number="ft")
         == "tíu þúsund tvö hundruðustu og öðrum"
     )
-    assert number_to_ordinal(1000000, "þf", "kvk", "et") == "milljónustu"
-    assert number_to_ordinal(1000000002, "þf", "kvk", "et") == "milljörðustu og aðra"
+    assert (
+        number_to_ordinal(1000000, case="þf", gender="kvk", number="et")
+        == "milljónustu"
+    )
+    assert (
+        number_to_ordinal(1000000002, case="þf", gender="kvk", number="et")
+        == "milljörðustu og aðra"
+    )
+
+    assert (
+        numbers_to_ordinal("Ég lenti í 41. sæti.", case="þgf")
+        == "Ég lenti í fertugasta og fyrsta sæti."
+    )
+    assert (
+        numbers_to_ordinal("2. í röðinni var hæstur.") == "annar í röðinni var hæstur."
+    )
+    assert (
+        numbers_to_ordinal("1. konan lenti í 2. sæti.", regex=r"1\.", gender="kvk")
+        == "fyrsta konan lenti í 2. sæti."
+    )
+    assert (
+        numbers_to_ordinal("fyrsta konan lenti í 2. sæti.", gender="hk", case="þgf")
+        == "fyrsta konan lenti í öðru sæti."
+    )
+    assert (
+        numbers_to_ordinal("Ég var 10201. í röðinni.")
+        == "Ég var tíu þúsund tvö hundraðasti og fyrsti í röðinni."
+    )
 
 
 def test_floats():
     """Test float to written text conversion."""
-    from queries.num import float_to_text
+    from queries.num import float_to_text, floats_to_text
 
-    assert float_to_text(-0.12) == "mínus núll komma eitt tvö"
-    assert float_to_text(-21.12, "kk") == "mínus tuttugu og einn komma einn tveir"
-    assert float_to_text(1.03, "kvk") == "ein komma núll þrjár"
+    assert float_to_text(-0.12) == "mínus núll komma tólf"
+    assert float_to_text(-0.1012) == "mínus núll komma eitt núll eitt tvö"
+    assert float_to_text(-21.12, gender="kk") == "mínus tuttugu og einn komma tólf"
+    assert (
+        float_to_text(-21.123, gender="kk")
+        == "mínus tuttugu og einn komma einn tveir þrír"
+    )
+    assert float_to_text(1.03, gender="kvk") == "ein komma núll þrjár"
+
+    assert (
+        floats_to_text("2,13 millilítrar af vökva.", gender="kk")
+        == "tveir komma þrettán millilítrar af vökva."
+    )
+    assert floats_to_text("0,04 prósent.") == "núll komma núll fjögur prósent."
+    assert (
+        floats_to_text("101,0021 prósent.")
+        == "hundrað og eitt komma núll núll tuttugu og eitt prósent."
+    )
 
 
 def test_digits():
@@ -1367,11 +1493,25 @@ def test_digits():
 
     assert digits_to_text("5885522") == "fimm átta átta fimm fimm tveir tveir"
     assert digits_to_text("112") == "einn einn tveir"
-    assert digits_to_text("123-0679") == "einn tveir þrír núll sex sjö níu"
-    assert digits_to_text(["12", "", "342"]) == "einn tveir þrír fjórir tveir"
+    assert digits_to_text("123-0679") == "einn tveir þrír-núll sex sjö níu"
+    assert (
+        digits_to_text("Síminn minn er 12342")
+        == "Síminn minn er einn tveir þrír fjórir tveir"
+    )
     assert digits_to_text("581 2345") == "fimm átta einn tveir þrír fjórir fimm"
-    assert digits_to_text([581, "-", 2345]) == "fimm átta einn tveir þrír fjórir fimm"
+    assert (
+        digits_to_text("5812345, það er síminn hjá þeim.")
+        == "fimm átta einn tveir þrír fjórir fimm, það er síminn hjá þeim."
+    )
     assert (
         digits_to_text("010270-2039")
-        == "núll einn núll tveir sjö núll tveir núll þrír níu"
+        == "núll einn núll tveir sjö núll-tveir núll þrír níu"
+    )
+    assert (
+        digits_to_text("192 0-1-127", regex=r"\d\d\d")
+        == "einn níu tveir 0-1-einn tveir sjö"
+    )
+    assert (
+        digits_to_text("Hringdu í 1-800-BULL", regex=r"\d+-\d+")
+        == "Hringdu í einn átta núll núll-BULL"
     )


### PR DESCRIPTION
- Added functions in `queries/num.py` for replacing numbers/floats/ordinals in strings with Icelandic text for voice engine, along with fixes to older number to text functions.
- Added argument to functions `time_period_desc` and `distance_desc` in `queries/__init__.py` which converts numbers to Icelandic text.
- Modified a bunch of modules to use the new functions to ensure correct pronounciation of numbers, and cleaned up redundant lookup tables (e.g. for ordinals).
- Added tests for the new functions and voice output of the modified modules.
- Fixed output wording of flights and sunpos module to be more flexible (and correct).
- Changed calls to `str.format()` into f-strings where appropriate.