### PR TITLE
Small temporary fix for wrong declension in person titles

### DIFF
--- a/processors/persons.py
+++ b/processors/persons.py
@@ -78,6 +78,8 @@
 import re
 from datetime import datetime
 
+from reynir import NounPhrase
+
 from db.models import Person
 
 from queries import QueryStateDict
@@ -212,7 +214,8 @@ def sentence(state: QueryStateDict, result: Result) -> None:
             person = Person(
                 article_url=url,
                 name=nafn,
-                title=titill,
+                # Try to get nominative form, otherwise fall back to raw text
+                title=NounPhrase(titill).nominative or titill,
                 title_lc=titill.lower(),
                 gender=kyn,
                 authority=authority,
@@ -292,7 +295,7 @@ def Titill(node, params, result):
     """Titill á eftir nafni"""
     # print("Titill: {0}".format(result["_text"]))
     if "ekki_titill" not in result:
-        result.titill = result._nominative
+        result.titill = result._text
 
 
 def KommuTitill(node, params, result):
@@ -314,7 +317,7 @@ def NlTitill(node, params, result):
 def EinnTitill(node, params, result):
     """Einn titill af hugsanlega fleirum í lista"""
     if "ekki_titill" not in result:
-        result.titlar = [result._nominative]
+        result.titlar = [result._text]
 
 
 def EfLiður(node, params, result):
@@ -424,7 +427,7 @@ def NlSkýring(node, params, result):
             s = " ".join([words[1], words[0]] + words[2:])
     else:
         # Ég talaði við Jón (heimsmethafa í hástökki)
-        s = cut(result._nominative)
+        s = cut(result._text)
 
     if s.lower() in NOT_EXPLANATION:
         s = None
@@ -489,7 +492,7 @@ def NlKjarni(node, params, result):
             kyn = result.get("skýring_kyn")
             if mannsnafn and kyn:
                 # print("NlKjarni: mannsnafn úr skýringu er '{0}', allur texti er '{1}'".format(mannsnafn, result._nominative))
-                titill = result._nominative
+                titill = result._text
                 # Skera nafnið og tákn (sviga/hornklofa/bandstrik/kommur) aftan af
                 rdelim = titill[-2:]
                 titill = titill[:-2]

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -232,6 +232,15 @@ def test_persons():
 
     Nikulás Tesla, serbneskur uppfinningamaður, lagði grunninn að riðstraumskerfum.
 
+    Lofthæna Guðrúnardóttir, lektor við Háskóla Íslands og rektor Listaháskólans,
+    tók til máls á ráðstefnunni.
+
+    Jónína Jónsdóttir (kennari í Háskólanum í Brandenburg) tók einnig til máls.
+
+    Jónas Guðmundsson, sviðsstjóri hjá Ríkisskattstjóra, hafði mikið um málið að segja.
+
+    "Það er ótrúlegt hve margir heita Jó-eitthvað," samkvæmt Jóhönnu Jóhannsdóttur, forstöðumanni hjá Háskólanum í Reykjavík.
+
     """
 
     tree, _ = _make_tree(text)
@@ -244,6 +253,16 @@ def test_persons():
     session.check(("Jói Biden", "bandaríkjaforseti", "kk"))
     session.check(("Albert Bourla", "forstjóri Pfizer", "kk"))
     session.check(("Nikulás Tesla", "serbneskur uppfinningamaður", "kk"))
+    session.check(
+        (
+            "Lofthæna Guðrúnardóttir",
+            "lektor við Háskóla Íslands og rektor Listaháskólans",
+            "kvk",
+        )
+    )
+    session.check(("Jónína Jónsdóttir", "kennari í Háskólanum í Brandenburg", "kvk"))
+    session.check(("Jónas Guðmundsson", "sviðsstjóri hjá Ríkisskattstjóra", "kk"))
+    session.check(("Jóhanna Jóhannsdóttir", "forstöðumaður hjá Háskólanum í Reykjavík", "kvk"))
 
     assert session.is_empty()
 


### PR DESCRIPTION
Small fix to person titles which had words in incorrect cases, such as 'lektor við Háskóli Íslands' (now becomes 'lektor við Háskóla Íslands').
(I only call it temporary because later I would like to refactor some of the the processor code to better utilize handy functions from GreynirPackage.)