### PR TITLE
Normalized and improved `bus.py` module

### DIFF
--- a/queries/bus.py
+++ b/queries/bus.py
@@ -36,33 +36,32 @@
 
 # TODO: Hvar er nálægasta strætóstoppistöð?
 # TODO: Hvað er ég lengi í næsta strætóskýli?
+# TODO: Hvar stoppar sjöan næst?
 
-from typing import Iterable, Optional, List, Set, Tuple, Union, cast
+from typing import Dict, Iterable, Optional, List, Set, Tuple, cast
 
+import re
+import random
 from threading import Lock
 from functools import lru_cache
 from datetime import datetime
-import random
 
-from islenska.basics import BinEntry
+from reynir import NounPhrase
 
-import queries
-from queries import AnswerTuple, Query, QueryStateDict, ResponseType, Session
-from tree import Result, Node
+from queries import AnswerTuple, Query, QueryStateDict
+from tree import Result, Node, ParamList
 from queries.util import (
+    is_plural,
     natlang_seq,
     cap_first,
     gen_answer,
     read_grammar_file,
-    sing_or_plur,
 )
-from speech.norm.num import floats_to_text, numbers_to_text
+from speech.norm import gssml, strip_markup
 from settings import Settings
-from reynir import correct_spaces
 from geo import in_iceland
 
-import straeto  # type: ignore  # TODO
-
+import straeto
 
 # Today's bus schedule, cached
 SCHEDULE_TODAY: Optional[straeto.BusSchedule] = None
@@ -148,44 +147,44 @@ GRAMMAR = read_grammar_file("bus")
 # tree processing (depth-first, i.e. bottom-up navigation).
 
 
-def QBusNearestStop(node: Node, params: QueryStateDict, result: Result) -> None:
+def QBusNearestStop(node: Node, params: ParamList, result: Result) -> None:
     """Nearest stop query"""
     result.qtype = "NearestStop"
     # No query key in this case
     result.qkey = ""
 
 
-def QBusStop(node: Node, params: QueryStateDict, result: Result) -> None:
+def QBusStop(node: Node, params: ParamList, result: Result) -> None:
     """Save the word that was used to describe a bus stop"""
     result.stop_word = _WRONG_STOP_WORDS.get(result._nominative, result._nominative)
 
 
-def QBusStopName(node: Node, params: QueryStateDict, result: Result) -> None:
+def QBusStopName(node: Node, params: ParamList, result: Result) -> None:
     """Save the bus stop name"""
     result.stop_name = result._nominative
 
 
-def QBusStopThere(node: Node, params: QueryStateDict, result: Result) -> None:
+def QBusStopThere(node: Node, params: ParamList, result: Result) -> None:
     """A reference to a bus stop mentioned earlier"""
     result.stop_name = "þar"
 
 
-def QBusStopToThere(node: Node, params: QueryStateDict, result: Result) -> None:
+def QBusStopToThere(node: Node, params: ParamList, result: Result) -> None:
     """A reference to a bus stop mentioned earlier"""
     result.stop_name = "þangað"
 
 
-def EfLiður(node: Node, params: QueryStateDict, result: Result) -> None:
+def EfLiður(node: Node, params: ParamList, result: Result) -> None:
     """Don't change the case of possessive clauses"""
     result._nominative = result._text
 
 
-def FsMeðFallstjórn(node: Node, params: QueryStateDict, result: Result) -> None:
+def FsMeðFallstjórn(node: Node, params: ParamList, result: Result) -> None:
     """Don't change the case of prepositional clauses"""
     result._nominative = result._text
 
 
-def QBusNoun(node: Node, params: QueryStateDict, result: Result) -> None:
+def QBusNoun(node: Node, params: ParamList, result: Result) -> None:
     """Save the noun used to refer to a bus"""
     # Use singular, indefinite form
     # Hack: if the QBusNoun is a literal string, the _canonical logic
@@ -197,7 +196,7 @@ def QBusNoun(node: Node, params: QueryStateDict, result: Result) -> None:
     result.bus_noun = result._canonical
 
 
-def QBusArrivalTime(node: Node, params: QueryStateDict, result: Result) -> None:
+def QBusArrivalTime(node: Node, params: ParamList, result: Result) -> None:
     """Bus arrival time query"""
     # Set the query type
     result.qtype = "ArrivalTime"
@@ -208,7 +207,7 @@ def QBusArrivalTime(node: Node, params: QueryStateDict, result: Result) -> None:
         result.qkey = result.bus_number
 
 
-def QBusAnyArrivalTime(node: Node, params: QueryStateDict, result: Result) -> None:
+def QBusAnyArrivalTime(node: Node, params: ParamList, result: Result) -> None:
     """Bus arrival time query"""
     # Set the query type
     result.qtype = "ArrivalTime"
@@ -216,7 +215,7 @@ def QBusAnyArrivalTime(node: Node, params: QueryStateDict, result: Result) -> No
     result.qkey = result.bus_number = "Any"
 
 
-def QBusWhich(node: Node, params: QueryStateDict, result: Result) -> None:
+def QBusWhich(node: Node, params: ParamList, result: Result) -> None:
     """Buses on which routes stop at a given stop"""
     # Set the query type
     result.qtype = "WhichRoute"
@@ -240,53 +239,10 @@ _BUS_WORDS = {
     "tía": 10,
     "ellefa": 11,
     "tólfa": 12,
-    "einn": 1,
-    "eitt": 1,
-    "tveir": 2,
-    "tvö": 2,
-    "þrír": 3,
-    "þrjú": 3,
-    "fjórir": 4,
-    "fjögur": 4,
-    "fimm": 5,
-    "sex": 6,
-    "sjö": 7,
-    "níu": 9,
-    "tíu": 10,
-    "ellefu": 11,
-    "tólf": 12,
-    "þrettán": 13,
-    "fjórtán": 14,
-    "fimmtán": 15,
-    "sextán": 16,
-    "sautján": 17,
-    "átján": 18,
-    "nítján": 19,
-    "tuttugu": 20,
-    "þrjátíu": 30,
-    "fjörutíu": 40,
-    "fimmtíu": 50,
-    "sextíu": 60,
-    "sjötíu": 70,
-    "áttatíu": 80,
-    "níutíu": 90,
-    # Hack to catch common ASR error
-    "hundrað eitt": 101,
-    "hundrað tvö": 102,
-    "hundrað þrjú": 103,
-    "hundrað fjögur": 104,
-    "hundrað fimm": 105,
-    "hundrað sex": 106,
-    "hundrað og eitt": 101,
-    "hundrað og tvö": 102,
-    "hundrað og þrjú": 103,
-    "hundrað og fjögur": 104,
-    "hundrað og fimm": 105,
-    "hundrað og sex": 106,
 }
 
 
-def QBusWord(node: Node, params: QueryStateDict, result: Result) -> None:
+def QBusWord(node: Node, params: ParamList, result: Result) -> None:
     """Handle buses specified in single words,
     such as 'tvisturinn' or 'fimman'"""
     # Retrieve the contained text (in nominative case)
@@ -301,81 +257,151 @@ def QBusWord(node: Node, params: QueryStateDict, result: Result) -> None:
     result.bus_number = _BUS_WORDS.get(result._canonical, 0)
 
 
-def QBusNumber(node: Node, params: QueryStateDict, result: Result) -> None:
+def QBusNumber(node: Node, params: ParamList, result: Result) -> None:
     """Reflect back the phrase used to specify the bus,
-    but in nominative case."""
+    but in nominative case. Also fetch specified bus number."""
     # 'vagni númer 17' -> 'vagn númer 17'
     # 'leið fimm' -> 'leið fimm'
     result.bus_name = result._nominative
 
-
-def QBusNumberWord(node: Node, params: QueryStateDict, result: Result) -> None:
-    """Obtain the bus number as an integer from word or number terminals."""
-    # Use the nominative, singular, indefinite form
-    number = result._canonical
-    try:
-        # Handle digits ("17")
-        result.bus_number = int(number)
-    except ValueError:
-        # Handle number words ("sautján")
-        result.bus_number = _BUS_WORDS.get(number, 0)
-        if Settings.DEBUG and result.bus_number == 0:
-            print("Unexpected bus number word: {0}".format(number))
-    except Exception as e:
-        if Settings.DEBUG:
-            print("Unexpected exception: {0}".format(e))
-        raise
+    if "numbers" in result and result.numbers:
+        result.bus_number = result.numbers[0]
 
 
 # End of grammar nonterminal handlers
 
 
-def _filter_func(mm: Iterable[BinEntry]) -> List[BinEntry]:
-    """Filter word meanings when casting bus stop names
-    to cases other than nominative"""
-    # Handle secondary and ternary forms (ÞFFT2, ÞGFET3...)
-    # This is a bit hacky, but necessary for optimal results.
-    # For place names, ÞGFET2 seems often to be a better choice
-    # than ÞGFET, since it has a trailing -i
-    # (for instance 'Skjólvangi' instead of 'Skjólvang')
-    mm2 = [m for m in mm if "ÞGF" in m.mark and "2" in m.mark]
-    if not mm2:
-        # Did not find the preferred ÞGF2, so we go for the
-        # normal form and cut away the secondary and ternary ones
-        mm2 = [m for m in mm if "2" not in m.mark and "3" not in m.mark]
-    return mm2 or list(mm)
+def _compass_directions(stop: str) -> str:
+    """
+    Replace '... N/A/S/V' with '... norður/austur/suður/vestur'
+    for speech synthesis.
+    """
+    if stop.endswith(" N") and straeto.BusStop.named(stop[:-1] + "S"):
+        stop = stop[:-1] + "norður"
+    elif stop.endswith(" A") and straeto.BusStop.named(stop[:-1] + "V"):
+        stop = stop[:-1] + "austur"
+    elif stop.endswith(" S") and straeto.BusStop.named(stop[:-1] + "N"):
+        stop = stop[:-1] + "suður"
+    elif stop.endswith(" V") and straeto.BusStop.named(stop[:-1] + "A"):
+        stop = stop[:-1] + "vestur"
+    return stop
+
+
+_BETTER_NAMES = {
+    "BSÍ": "Umferðarmiðstöðin",
+    "FMOS": "Framhaldsskólinn í Mosfellsbæ",
+    "KEF - Airport": "Keflavíkurflugvöllur",
+    "KR": "Knattspyrnufélag Reykjavíkur",
+    "RÚV": "Útvarpshúsið",
+}
+_ABBREV_RE = re.compile(r"\b[A-ZÁÐÉÍÓÚÝÞÆÖ]+\b")
+
+
+def voicify_stop_name(np: str) -> str:
+    """Fix stop name to better suit speech synthesis."""
+    np = _compass_directions(np)
+    np = _BETTER_NAMES.get(np, np)
+    return _ABBREV_RE.sub(lambda m: gssml(m.group(0), type="spell"), np)
 
 
 @lru_cache(maxsize=None)
-def to_accusative(np: str) -> str:
-    """Return the noun phrase after casting it from nominative to accusative case"""
-    np = straeto.BusStop.voice(np)
-    return queries.to_accusative(np, filter_func=_filter_func)
+def accusative_form(np: str, voice: bool = False) -> str:
+    """
+    Return accusative case of the stop name,
+    optionally expanding abbreviations for speech synthesis.
+    """
+    if voice:
+        np = _compass_directions(np)
+        np = _BETTER_NAMES.get(np, np)
+
+    split_symb = None
+    if " / " in np:
+        split_symb = " / "
+    elif " - " in np:
+        split_symb = " - "
+
+    if split_symb is None:
+        # Bus stop is single noun phrase
+        np = NounPhrase(np).accusative or np
+    else:
+        # Bus stop consists of two (at least) noun phrases
+        # separated by split_symb, inflect them separately
+        new_np: List[str] = []
+        for n in np.split(split_symb):
+            if any(c.islower() for c in n):
+                # Not an all-uppercase abbreviation, try to inflect it
+                n = NounPhrase(n).accusative or n
+            new_np.append(n)
+        np = split_symb.join(new_np)
+    if voice:
+        np = _ABBREV_RE.sub(lambda m: gssml(m.group(0), type="spell"), np)
+    return np
 
 
 @lru_cache(maxsize=None)
-def to_dative(np: str) -> str:
-    """Return the noun phrase after casting it from nominative to dative case"""
-    np = straeto.BusStop.voice(np)
-    return queries.to_dative(np, filter_func=_filter_func)
+def dative_form(np: str, voice: bool = False) -> str:
+    """
+    Return dative case of the stop name,
+    optionally expanding abbreviations for speech synthesis.
+    """
+    if voice:
+        np = _compass_directions(np)
+        np = _BETTER_NAMES.get(np, np)
+
+    split_symb = None
+    if " / " in np:
+        split_symb = " / "
+    elif " - " in np:
+        split_symb = " - "
+
+    if split_symb is None:
+        # Bus stop is single noun phrase
+        np = NounPhrase(np).dative or np
+    else:
+        # Bus stop consists of two (at least) noun phrases
+        # separated by split_symb, inflect them separately
+        new_np: List[str] = []
+        for n in np.split(split_symb):
+            if any(c.islower() for c in n):
+                # Not an uppercase abbreviation, inflect it
+                n = NounPhrase(n).dative or n
+            new_np.append(n)
+        np = split_symb.join(new_np)
+    if voice:
+        np = _ABBREV_RE.sub(lambda m: gssml(m.group(0), type="spell"), np)
+    return np
 
 
 def voice_distance(d: float) -> str:
     """Convert a distance, given as a float in units of kilometers, to a string
-    that can be read aloud in Icelandic"""
+    that can be read aloud in Icelandic starting with 'þangað er' or 'þangað eru'."""
+    are = "eru"
     # Distance more than 1 kilometer
     if d >= 1:
-        km: float = round(d, 1)
-        out_str = sing_or_plur(km, "kílómetri", "kílómetrar")
-        return floats_to_text(out_str, gender="kk", comma_null=False)
+        km = round(d, 1)
+        vdist = gssml(km, type="float", gender="kk")
+        if is_plural(km):
+            unit = "kílómetrar"
+        else:
+            are = "er"
+            unit = "kílómetri"
+    else:
+        # Distance less than 1 km: Round to 10 meters
+        m = int(round(d * 1000, -1))
+        vdist = gssml(m, type="number", gender="kk")
+        unit = "metrar"
+    return " ".join(("þangað", are, vdist, unit))
 
-    # Distance less than 1 km: Round to 10 meters
-    m: int = int(round(d * 1000, -1))
-    return numbers_to_text(f"{m} metrar", gender="kk")
+
+# Hours, minutes, seconds
+_HMSTuple = Tuple[int, int, int]
 
 
-def hms_fmt(hms: Tuple[int, int, int]) -> str:
-    """Format a (h, m, s) tuple to a HH:MM string"""
+def hms_fmt(hms: _HMSTuple, voice: bool = False) -> str:
+    """
+    Format a (h, m, s) tuple to a HH:MM string,
+    optionally enclosed by <greynir type='time'>
+    """
     h, m, s = hms
     if s >= 30:
         # Round upwards
@@ -390,24 +416,24 @@ def hms_fmt(hms: Tuple[int, int, int]) -> str:
         m -= 60
     if h >= 24:
         h -= 24
-    return "{0:02}:{1:02}".format(h, m)
+    return gssml(f"{h:02}:{m:02}", type="time") if voice else f"{h:02}:{m:02}"
 
 
-def hms_diff(hms1: Tuple, hms2: Tuple) -> int:
+def hms_diff(hms1: _HMSTuple, hms2: _HMSTuple) -> int:
     """Return (hms1 - hms2) in minutes, where both are (h, m, s) tuples"""
     return (hms1[0] - hms2[0]) * 60 + (hms1[1] - hms2[1])
 
 
-def query_nearest_stop(query: Query, session: Session, result: Result) -> AnswerTuple:
+def query_nearest_stop(query: Query, result: Result) -> AnswerTuple:
     """A query for the stop closest to the user"""
     # Retrieve the client location
     location = query.location
     if location is None:
         # No location provided in the query
-        answer = "Staðsetning óþekkt"
-        response = dict(answer=answer)
+        answer = "Staðsetning óþekkt."
         voice_answer = "Ég veit ekki hvar þú ert."
-        return response, answer, voice_answer
+        return dict(answer=answer), answer, voice_answer
+
     if not in_iceland(location):
         # User's location is not in Iceland
         return gen_answer("Ég þekki ekki strætósamgöngur utan Íslands.")
@@ -416,26 +442,20 @@ def query_nearest_stop(query: Query, session: Session, result: Result) -> Answer
     stop = straeto.BusStop.closest_to(location)
     if stop is None:
         return gen_answer("Ég finn enga stoppistöð nálægt þér.")
-    answer = stop.name
+
+    answer = stop.name + "."
     # Use the same word for the bus stop as in the query
-    stop_word = result.stop_word if "stop_word" in result else "stoppistöð"
-    va = [
-        "Næsta",
-        stop_word,
-        "er",
-        stop.name + ";",
-        "þangað",
-        "eru",
-        voice_distance(straeto.distance(location, stop.location)),
-    ]
+    stop_word = result.get("stop_word", "stoppistöð")
+    voice_answer = (
+        f"Næsta {stop_word} er {voicify_stop_name(stop.name)}; "
+        f"{voice_distance(straeto.distance(location, stop.location))}."
+    )
     # Store a location coordinate and a bus stop name in the context
     query.set_context({"location": stop.location, "bus_stop": stop.name})
-    voice_answer = " ".join(va) + "."
-    response = dict(answer=answer)
-    return response, answer, voice_answer
+    return dict(answer=answer), answer, voice_answer
 
 
-def query_arrival_time(query: Query, session: Session, result: Result):
+def query_arrival_time(query: Query, result: Result) -> AnswerTuple:
     """Answers a query for the arrival time of a bus"""
 
     # Examples:
@@ -455,17 +475,14 @@ def query_arrival_time(query: Query, session: Session, result: Result):
         if ctx and "bus_stop" in ctx:
             stop_name = cast(str, ctx["bus_stop"])
         else:
-            answer = voice_answer = "Ég veit ekki við hvaða stað þú átt."
-            response = dict(answer=answer)
-            return response, answer, voice_answer
+            return gen_answer("Ég veit ekki við hvaða stað þú átt.")
 
     if not stop_name:
         location = query.location
         if location is None:
-            answer = "Staðsetning óþekkt"
-            response = dict(answer=answer)
+            answer = "Staðsetning óþekkt."
             voice_answer = "Ég veit ekki hvar þú ert."
-            return response, answer, voice_answer
+            return dict(answer=answer), answer, voice_answer
 
     # Obtain today's bus schedule
     global SCHEDULE_TODAY
@@ -485,10 +502,7 @@ def query_arrival_time(query: Query, session: Session, result: Result):
     else:
         # Obtain the closest stops (at least within 400 meters radius)
         assert location is not None
-        stops = cast(
-            List[straeto.BusStop],
-            straeto.BusStop.closest_to_list(location, n=2, within_radius=0.4),
-        )
+        stops = straeto.BusStop.closest_to_list(location, n=2, within_radius=0.4)
         if not stops:
             # This will fetch the single closest stop, regardless of distance
             stops = [cast(straeto.BusStop, straeto.BusStop.closest_to(location))]
@@ -504,35 +518,41 @@ def query_arrival_time(query: Query, session: Session, result: Result):
                 if route is not None:
                     numbers.add(route.number)
                     stops_canonical.add(stop.name)
-        routes = sorted(list(numbers), key=lambda r: int(r))
-        if len(routes) != 1:
+
+        if len(numbers) != 1:
             # More than one route possible: ask user to clarify
-            route_seq = natlang_seq(list(map(str, routes)))
+            route_seq = natlang_seq(sorted(numbers, key=lambda n: int(n)))
             # "Einarsnesi eða Einarsnesi/Bauganesi"
-            stops_list = " eða ".join([to_dative(s) for s in stops_canonical])
-            answer = (
-                " ".join(["Leiðir", route_seq, "stoppa á", stops_list])
-                + ". Spurðu um eina þeirra."
+            stops_list = natlang_seq([dative_form(s) for s in sorted(stops_canonical)])
+            va_stops_list = " eða ".join(
+                [dative_form(s, voice=True) for s in sorted(stops_canonical)]
             )
+            answer = f"Leiðir {route_seq} stoppa á {stops_list}. Spurðu um eina þeirra."
             voice_answer = (
-                " ".join(["Leiðir", numbers_to_text(route_seq), "stoppa á", stops_list])
-                + ". Spurðu um eina þeirra."
+                f"Leiðir {gssml(route_seq, type='numbers')}"
+                f" stoppa á {va_stops_list}."
+                " Spurðu um eina þeirra."
             )
-            response = dict(answer=answer)
-            return response, answer, voice_answer
+            return dict(answer=answer), answer, voice_answer
+
         # Only one route: use it as the query subject
-        bus_number = routes[0]
-        bus_name = "strætó númer {0}".format(bus_number)
+        bus_number = numbers.pop()
+        bus_name = "Strætó númer {0}".format(bus_number)
+        va = [f"Strætó númer {gssml(bus_number, type='number')}"]
     else:
-        bus_number = result.bus_number if "bus_number" in result else 0
-        bus_name = result.bus_name if "bus_name" in result else "Óþekkt"
+        bus_number = result.get("bus_number", 0)
+        bus_name = cap_first(result.bus_name) if "bus_name" in result else "Óþekkt"
+        va = [gssml(bus_name, type="numbers")]
+        if bus_number < 0:
+            # Negative bus numbers don't exist
+            answer = f"{bus_name} er ekki til."
+            voice_answer = f"{va[0]} er ekki til."
+            return dict(answer=answer), answer, voice_answer
 
     # Prepare results
-    bus_name = cap_first(bus_name)
-    va = [numbers_to_text(bus_name)]
-    a = []
-    arrivals = []
-    arrivals_dict = {}
+    a: List[str] = []
+    arrivals: List[Tuple[str, List[_HMSTuple]]] = []
+    arrivals_dict: Dict[str, List[_HMSTuple]] = {}
     arrives = False
     route_number = str(bus_number)
 
@@ -547,7 +567,7 @@ def query_arrival_time(query: Query, session: Session, result: Result):
                 break
         arrivals = list(arrivals_dict.items())
         assert stop is not None
-        a = ["Á", to_accusative(stop.name), "í átt að"]
+        a = [f"Á {accusative_form(stop.name)} í átt að"]
 
     if arrivals:
         # Get a predicted arrival time for each direction from the
@@ -568,9 +588,9 @@ def query_arrival_time(query: Query, session: Session, result: Result):
             if not first:
                 va.append(", og")
                 a.append(". Í átt að")
-            va.extend(["í átt að", to_dative(direction)])
-            a.append(to_dative(direction))
-            deviation = []
+            va.append(f"í átt að {dative_form(direction, voice=True)}")
+            a.append(dative_form(direction))
+            deviation: str = ""
             if prediction and direction in prediction:
                 # We have a predicted arrival time
                 hms_sched = times[0]
@@ -579,7 +599,7 @@ def query_arrival_time(query: Query, session: Session, result: Result):
                 # now, and skip it if it is 1 minute or less
                 diff = hms_diff(hms_pred, hms_now)
                 if abs(diff) <= 1:
-                    deviation = [", en er að fara núna"]
+                    deviation = ", en er að fara núna"
                 else:
                     # Calculate the difference in minutes between the
                     # schedule and the prediction, with a positive number
@@ -589,29 +609,27 @@ def query_arrival_time(query: Query, session: Session, result: Result):
                         # More than one minute ahead of schedule
                         if diff < -5:
                             # More than 5 minutes ahead
-                            deviation = [
-                                ", en kemur sennilega fyrr, eða",
-                                hms_fmt(hms_pred),
-                            ]
+                            deviation = (
+                                ", en kemur sennilega fyrr, "
+                                f"eða {hms_fmt(hms_pred, voice=True)}"
+                            )
                         else:
                             # Two to five minutes ahead
-                            deviation = [
-                                ", en er",
-                                str(-diff),
-                                "mínútum á undan áætlun",
-                            ]
+                            deviation = f", en er {-diff} mínútum á undan áætlun"
+
                     elif diff >= 3:
                         # 3 minutes or more behind schedule
-                        deviation = [
-                            ", en kemur sennilega ekki fyrr en",
-                            hms_fmt(hms_pred),
-                        ]
+                        deviation = (
+                            ", en kemur sennilega ekki fyrr "
+                            f"en {hms_fmt(hms_pred, voice=True)}"
+                        )
             if first:
                 assert stop is not None
                 if deviation:
-                    va.extend(["á að koma á", to_accusative(stop.name)])
+                    va.append("á að koma á")
                 else:
-                    va.extend(["kemur á", to_accusative(stop.name)])
+                    va.append("kemur á")
+                va.append(accusative_form(stop.name, voice=True))
             va.append("klukkan")
             a.append("klukkan")
             if len(times) == 1 or (
@@ -620,34 +638,34 @@ def query_arrival_time(query: Query, session: Session, result: Result):
                 # Either we have only one arrival time, or the next arrival is
                 # at least 10 minutes away: only pronounce one time
                 hms = times[0]
-                time_text = hms_fmt(hms)
+                time_text = hms_fmt(hms, voice=True)
             else:
                 # Return two or more times
-                time_text = " og ".join(hms_fmt(hms) for hms in times)
+                time_text = " og ".join(hms_fmt(hms, voice=True) for hms in times)
             va.append(time_text)
-            a.append(time_text)
-            va.extend(deviation)
-            a.extend(deviation)
+            a.append(strip_markup(time_text))  # Remove greynir SSML tags
+            if deviation:
+                va.append(deviation)
+                a.append(strip_markup(deviation))
             first = False
 
     elif arrives:
         # The given bus has already completed its scheduled halts at this stop today
         assert stops
         stop = stops[0]
-        reply = ["kemur ekki aftur á", to_accusative(stop.name), "í dag"]
-        va.extend(reply)
-        a = [bus_name] + reply
+        va.append(f"kemur ekki aftur á {accusative_form(stop.name, voice=True)} í dag")
+        a = [bus_name, "kemur ekki aftur á", accusative_form(stop.name), "í dag"]
 
     elif stops:
         # The given bus doesn't stop at all at either of the two closest stops
         stop = stops[0]
-        va.extend(["stoppar ekki á", to_dative(stop.name)])
-        a = [bus_name, "stoppar ekki á", to_dative(stop.name)]
+        va.append(f"stoppar ekki á {dative_form(stop.name, voice=True)}")
+        a = [bus_name, "stoppar ekki á", dative_form(stop.name)]
 
     else:
         # The bus stop name is not recognized
         assert stop_name is not None
-        va = a = [stop_name.capitalize(), "er ekki biðstöð"]
+        va = a = [f"{stop_name.capitalize()} er ekki biðstöð"]
 
     if stop is not None:
         # Store a location coordinate and a bus stop name in the context
@@ -667,17 +685,20 @@ def query_arrival_time(query: Query, session: Session, result: Result):
         bq = bq.replace(*t)
     query.set_beautified_query(bq)
 
-    def assemble(x):
+    def assemble(x: Iterable[str]):
         """Intelligently join answer string components."""
-        return (" ".join(x) + ".").replace(" .", ".").replace(" ,", ",")
+        s = " ".join(x) + "."
+        s = re.sub(r"\s\s+", r" ", s)  # Shorten repeated whitespace
+        s = re.sub(r"\s([.,])", r"\1", s)  # Whitespace before comma/period
+        s = re.sub(r"([.,])+", r"\1", s)  # Multiple commas/periods
+        return s
 
-    voice_answer = assemble(va)
     answer = assemble(a)
-    response = dict(answer=answer)
-    return response, answer, voice_answer
+    voice_answer = assemble(va)
+    return dict(answer=answer), answer, voice_answer
 
 
-def query_which_route(query: Query, session: Session, result: Result):
+def query_which_route(query: Query, result: Result):
     """Which routes stop at a given bus stop"""
     stop_name = cast(str, result.stop_name)  # 'Einarsnes', 'Fiskislóð'...
 
@@ -688,51 +709,33 @@ def query_which_route(query: Query, session: Session, result: Result):
             stop_name = cast(str, ctx["bus_stop"])
             result.qkey = stop_name
         else:
-            answer = voice_answer = "Ég veit ekki við hvaða stað þú átt."
-            response = dict(answer=answer)
-            return response, answer, voice_answer
+            return gen_answer("Ég veit ekki við hvaða stað þú átt.")
 
     bus_noun = result.bus_noun  # 'strætó', 'vagn', 'leið'...
     stops = straeto.BusStop.named(stop_name, fuzzy=True)
     if not stops:
-        a = [stop_name, "þekkist ekki."]
-        va = ["Ég", "þekki", "ekki", "biðstöðina", stop_name.capitalize()]
+        answer = f"{stop_name} þekkist ekki."
+        voice_answer = f"Ég þekki ekki biðstöðina {stop_name}."
     else:
-        routes = set()
+        routes: Set[str] = set()
         if query.location:
             straeto.BusStop.sort_by_proximity(stops, query.location)
         stop = stops[0]
         for route_id in stop.visits.keys():
             route = straeto.BusRoute.lookup(route_id)
             if route is not None:
-                number = route.number
-                routes.add(number)
-        va = [bus_noun, "númer"]
-        a = va[:]
-        nroutes = len(routes)
-        cnt = 0
-        for rn in sorted(routes, key=lambda t: int(t)):
-            if cnt:
-                sep = "og" if cnt + 1 == nroutes else ","
-                va.append(sep)
-                a.append(sep)
-            # We convert inflectable numbers to their text equivalents
-            # since the speech engine can't be relied upon to get the
-            # inflection of numbers right
-            va.append(numbers_to_text(rn))
-            a.append(rn)
-            cnt += 1
-        tail = ["stoppar á", to_dative(stop.name)]
-        va.extend(tail)
-        a.extend(tail)
+                routes.add(route.number)
+        route_seq = natlang_seq(sorted(routes))
+        stop_verb = "stoppa" if is_plural(len(routes)) else "stoppar"
+        answer = f"{bus_noun} númer {route_seq} {stop_verb} á {dative_form(stop.name)}."
+        voice_answer = (
+            f"{bus_noun} númer {gssml(route_seq, type='numbers')} "
+            f"{stop_verb} á {dative_form(stop.name, voice=True)}."
+        )
         # Store a location coordinate and a bus stop name in the context
         query.set_context({"location": stop.location, "bus_stop": stop.name})
 
-    voice_answer = correct_spaces(" ".join(va) + ".")
-    answer = correct_spaces(" ".join(a))
-    answer = cap_first(answer)
-    response = dict(answer=answer)
-    return response, answer, voice_answer
+    return dict(answer=answer), cap_first(answer), cap_first(voice_answer)
 
 
 # Dispatcher for the various query types implemented in this module
@@ -753,29 +756,16 @@ def sentence(state: QueryStateDict, result: Result) -> None:
         # Successfully matched a query type
         q.set_qtype(result.qtype)
         q.set_key(result.qkey)
-        # SQLAlchemy session, if required
-        session = state["session"]
         # Select a query function and execute it
         qfunc = _QFUNC.get(result.qtype)
-        answer: Optional[str] = None
-        if qfunc is None:
-            # Something weird going on - should not happen
-            answer = cast(str, result.qtype) + ": " + cast(str, result.qkey)
-            q.set_answer(dict(answer=answer), answer)
-        else:
-            try:
-                voice_answer = None
-                response: Union[AnswerTuple, ResponseType] = qfunc(q, session, result)
-                if isinstance(response, tuple):
-                    # We have both a normal and a voice answer
-                    response, answer, voice_answer = response
-                assert answer is not None
-                q.set_answer(response, answer, voice_answer)
-            except AssertionError:
+        try:
+            assert qfunc is not None, "qfunc is None"
+            q.set_answer(*qfunc(q, result))
+        except AssertionError:
+            raise
+        except Exception as e:
+            if Settings.DEBUG:
                 raise
-            except Exception as e:
-                if Settings.DEBUG:
-                    raise
-                q.set_error("E_EXCEPTION: {0}".format(e))
+            q.set_error("E_EXCEPTION: {0}".format(e))
     else:
         q.set_error("E_QUERY_NOT_UNDERSTOOD")

--- a/queries/grammars/bus.grammar
+++ b/queries/grammars/bus.grammar
@@ -243,13 +243,8 @@ QBusWord/fall →
     | 'tólfa:kvk'_et_gr/fall
 
 QBusNumber/fall →
-    QBusNounSingular/fall QBusNr? QBusNumberWord
+    QBusNounSingular/fall QBusNr? UHeilTala
+    # UHeilTala is a nonterminal from the util modules, which
+    # matches any cardinal number and places it in the list result.numbers
 
 QBusNr → 'númer:hk'_et_nf | "nr"
-
-QBusNumberWord →
-
-    # to is a declinable number word ('tveir/tvo/tveim/tveggja')
-    # töl is an undeclinable number word ('sautján')
-    # tala is a number ('17')
-    "eitt" | to_nf_ft_hk | töl | tala

--- a/queries/util/number_grammar.py
+++ b/queries/util/number_grammar.py
@@ -33,12 +33,10 @@
 # TODO: 1 - Ordinal numbers
 # TODO: 2 - Fractions
 
-from typing import Any
-
 from functools import reduce
 from operator import mul
 
-from tree import Result
+from tree import Result, ParamList, Node
 from queries.util import read_utility_grammar_file
 
 # The context-free grammar for number utterances recognized by this utility module
@@ -93,7 +91,7 @@ _NUMBERS = {
 }
 
 
-def UBrotaTala(node: Any, params: Any, result: Result) -> None:
+def UBrotaTala(node: Node, params: ParamList, result: Result) -> None:
     if "numbers" in result:
         result["numbers"] = [
             float(
@@ -102,9 +100,16 @@ def UBrotaTala(node: Any, params: Any, result: Result) -> None:
         ]
 
 
+def UHeilTala(node: Node, params: ParamList, result: Result) -> None:
+    # Check if a number was specified in digits instead of written out
+    tala = node.first_child(lambda n: n.has_t_base("tala"))
+    if tala is not None and tala.contained_number is not None:
+        result["numbers"] = [int(tala.contained_number)]
+
+
 # Function for nonterminals which have children that should be multiplied together
 # e.g. "fimm" (5) and "hundruð" (100) -> "fimm hundruð" (500)
-def _multiply_children(node: Any, params: Any, result: Result) -> None:
+def _multiply_children(node: Node, params: ParamList, result: Result) -> None:
     if "numbers" in result:
         result["numbers"] = [reduce(mul, result["numbers"])]
 
@@ -130,7 +135,7 @@ def _multiply_children(node: Any, params: Any, result: Result) -> None:
 
 # Function for nonterminals which have children that should be added together
 # e.g. "sextíu" (60) and "átta" (8) -> "sextíu (og) átta" (68)
-def _sum_children(node: Any, params: Any, result: Result) -> None:
+def _sum_children(node: Node, params: ParamList, result: Result) -> None:
     if "numbers" in result:
         result["numbers"] = [sum(result["numbers"])]
 
@@ -158,7 +163,7 @@ def _sum_children(node: Any, params: Any, result: Result) -> None:
 
 # Function for nonterminals where we can perform a value lookup
 # e.g. "hundruð" (result._root = "hundrað") -> 100
-def _lookup_function(node: Any, params: Any, result: Result) -> None:
+def _lookup_function(node: Node, params: ParamList, result: Result) -> None:
     result["numbers"] = [_NUMBERS[result._root]]
 
 

--- a/speech/norm/__init__.py
+++ b/speech/norm/__init__.py
@@ -23,16 +23,9 @@
 
 """
 
-from typing import (
-    Any,
-    Callable,
-    Optional,
-    Union,
-    ChainMap as ChainMapType,
-)
+from typing import Any, Optional, Union
 
 import re
-from collections import ChainMap
 
 from speech.norm.num import (
     digits_to_text,
@@ -46,9 +39,15 @@ from speech.norm.num import (
     years_to_text,
 )
 
-# Each voice module in voices/ can define the NORM_HANDLERS variable
-# as its custom mapping of normalization functions
-NORM_MAP_VAR = "NORM_HANDLERS"
+# Each voice module in the directory speech/voices can define a
+# 'Normalization' class as a subclass of 'DefaultNormalization' in
+# order to override normalization functions/methods for a particular voice
+NORMALIZATION_CLASS = "Normalization"
+
+
+def strip_markup(text: str) -> str:
+    """Remove HTML/SSML tags from a string."""
+    return re.sub(r"<.*?>", "", text)
 
 
 def gssml(data: Any = None, *, type: str, **kwargs: Union[str, int, float]) -> str:
@@ -86,7 +85,7 @@ _CHAR_PRONUNCIATION = {
     "d": "dé",
     "ð": "eð",
     "e": "e",
-    "é": "je",
+    "é": "é",
     "f": "eff",
     "g": "gé",
     "h": "há",
@@ -125,14 +124,6 @@ def spell_out(s: str) -> str:
         return ""
     t = [_CHAR_PRONUNCIATION.get(c.lower(), c) if c != " " else "" for c in s]
     return " ".join(t).replace("  ", " ").strip()
-
-
-def _time_handler(t: str) -> str:
-    """Handles time of day data specified as 'HH:MM'."""
-    # TODO: Say e.g. "hálf fjögur" instead of "fimmtán þrjátíu"? "korter í/yfir"?
-    # TODO: Say "tuttugu mínútur yfir þrjú" instead of "fimmtán tuttugu"?
-    ts = [int(i) for i in t.split(":")]
-    return " ".join(number_to_text(x, gender="hk") for x in ts)
 
 
 _MONTH_ABBREVS = (
@@ -181,46 +172,6 @@ _DATE_REGEXES = (
 )
 
 
-def _date_handler(d: str, case: str = "nf") -> str:
-    """
-    Handles dates specified in either
-        'YYYY-MM-DD' (ISO 8601 format),
-        'DD/MM/YYYY' or
-        'DD. month[ YYYY]'
-    Note: doesn't check for incorrect numbers,
-          as that should be handled by caller.
-    """
-    # Get first fullmatch from date regexes
-    m = next(
-        filter(
-            lambda x: x is not None,
-            (r.fullmatch(d) for r in _DATE_REGEXES),
-        ),
-        None,  # Default if no matches are found
-    )
-    assert m is not None, f"Incorrect date format specified for date handler: {d}"
-
-    # Handle 'DD/MM/YYYY' or 'MM. jan/feb/... [year]' match
-    gd = m.groupdict()
-    day = number_to_ordinal(gd["day"], gender="kk", case=case, number="et")
-    month = (
-        _MONTH_NAMES[min(int(gd["month"]) - 1, 11)]  # DD/MM/YYYY specification
-        if gd["month"].isdecimal()
-        else _MONTH_NAMES[_MONTH_ABBREVS.index(gd["month"][:3])]  # Non-decimal
-    )
-    return (
-        f"{day} {month} {year_to_text(gd['year'])}" if gd["year"] else f"{day} {month}"
-    )
-
-
-def _abbrev_handler(txt: str) -> str:
-    return f' {spell_out(txt).replace(" ", _break_handler(strength="weak"))} '
-
-
-def _email_handler(email: str) -> str:
-    return email.replace("@", " hjá ").replace(".", " punktur ")
-
-
 # Break strength values:
 # none: No pause should be outputted. This can be used to remove a pause that would normally occur (such as after a period).
 # x-weak: No pause should be outputted (same as none).
@@ -231,42 +182,244 @@ def _email_handler(email: str) -> str:
 _STRENGTHS = frozenset(("none", "x-weak", "weak", "medium", "strong", "x-strong"))
 
 
-def _break_handler(time: Optional[str] = None, strength: Optional[str] = None):
-    if time:
-        return f'<break time="{time}" />'
-    if strength:
-        assert strength in _STRENGTHS, f"Break strength {strength} is invalid."
-        return f'<break strength="{strength}" />'
-    return f"<break />"
+class NormalizationHandler:  # Abstract base class
+    ...
 
 
-# Permissive normalization handler function type
-NormFunc = Callable[..., str]
-HANDLER_MAPTYPE = ChainMapType[str, NormFunc]
-# Default/Fallback normalization handlers,
-# voice modules can override the handlers by creating a ChainMap child
-DEFAULT_NORM_HANDLERS: HANDLER_MAPTYPE = ChainMap(
-    {
-        "number": number_to_text,
-        "numbers": numbers_to_text,
-        # ^ Plural forms are lazy shortcuts for longer text
-        # TODO: amount/s
-        # TODO: currency/ies
-        # TODO: distance/s
-        "float": float_to_text,
-        "floats": floats_to_text,
-        "ordinal": number_to_ordinal,
-        "ordinals": numbers_to_ordinal,
-        "digits": digits_to_text,
-        "phone": digits_to_text,
-        "time": _time_handler,
-        "date": _date_handler,
-        "year": year_to_text,
-        "years": years_to_text,
-        "abbrev": _abbrev_handler,
-        "email": _email_handler,
-        "break": _break_handler,
-        "paragraph": lambda txt: f"<p>{txt}</p>",
-        "sentence": lambda txt: f"<s>{txt}</s>",
+class DefaultNormalization(NormalizationHandler):
+    """
+    Class containing default text normalization functions
+    for Icelandic speech synthesis.
+    """
+
+    # TODO
+    # amount/s
+    # currency/ies
+    # distance/s
+
+    @classmethod
+    def number(cls, txt: str, **kwargs: str):
+        """Voicify a number."""
+        return number_to_text(txt, **kwargs)
+
+    @classmethod
+    def numbers(cls, txt: str, **kwargs: str):
+        """Voicify text containing multiple numbers."""
+        return numbers_to_text(txt, **kwargs)
+
+    @classmethod
+    def float(cls, txt: str, **kwargs: str):
+        """Voicify a float."""
+        return float_to_text(txt, **kwargs)
+
+    @classmethod
+    def floats(cls, txt: str, **kwargs: str):
+        """Voicify text containing multiple floats."""
+        return floats_to_text(txt, **kwargs)
+
+    @classmethod
+    def ordinal(cls, txt: str, **kwargs: str):
+        """Voicify an ordinal."""
+        return number_to_ordinal(txt, **kwargs)
+
+    @classmethod
+    def ordinals(cls, txt: str, **kwargs: str):
+        """Voicify text containing multiple ordinals."""
+        return numbers_to_ordinal(txt, **kwargs)
+
+    @classmethod
+    def digits(cls, txt: str):
+        """Spell out digits."""
+        return digits_to_text(txt)
+
+    @classmethod
+    def phone(cls, txt: str):
+        """Spell out digits."""
+        return cls.digits(txt)
+
+    @classmethod
+    def time(cls, txt: str):
+        """
+        Voicifies time of day, specified as 'HH:MM'.
+        E.g.
+            "11:34" -> "ellefu þrjátíu og fjögur",
+            "00:30" -> "tólf þrjátíu um nótt"
+        Note: doesn't check for incorrect data, caller should handle.
+        """
+        h, m = [int(i) for i in txt.split(":")]
+        suffix: Optional[str] = None
+        # Some times
+        if h == 0:
+            # Call 00:00 "tólf á miðnætti"
+            # and 00:xx "tólf ... um nótt"
+            h = 12
+            suffix = "á miðnætti" if m == 0 else "um nótt"
+        elif 0 < h <= 5:
+            suffix = "um nótt"
+        elif h == 12 and m == 0:
+            suffix = "um hádegi"
+        t = [
+            number_to_text(h, case="nf", gender="hk"),
+        ]
+        if m > 0:
+            if m < 10:
+                # e.g. "þrettán núll fjögur"
+                t.append("núll")
+            t.append(number_to_text(m, case="nf", gender="hk"))
+        if suffix:
+            t.append(suffix)
+        return " ".join(t)
+
+    @classmethod
+    def date(cls, txt: str, case: str = "nf"):
+        """
+        Voicifies dates specified in either
+            'YYYY-MM-DD' (ISO 8601 format),
+            'DD/MM/YYYY' or
+            'DD. month[ YYYY]'
+        Note: doesn't check for incorrect numbers,
+            as that should be handled by caller.
+        """
+        # Get first fullmatch from date regexes
+        m = next(
+            filter(
+                lambda x: x is not None,
+                (r.fullmatch(txt) for r in _DATE_REGEXES),
+            ),
+            None,  # Default if no matches are found
+        )
+        assert m is not None, f"Incorrect date format specified for date handler: {txt}"
+
+        # Handle 'DD/MM/YYYY' or 'MM. jan/feb/... [year]' match
+        gd = m.groupdict()
+        day = number_to_ordinal(gd["day"], gender="kk", case=case, number="et")
+        # Month names don't change in different declensions
+        month = (
+            _MONTH_NAMES[int(gd["month"]) - 1]  # DD/MM/YYYY specification
+            if gd["month"].isdecimal()
+            else _MONTH_NAMES[_MONTH_ABBREVS.index(gd["month"][:3])]  # Non-decimal
+        )
+        return (
+            f"{day} {month} {year_to_text(gd['year'])}"
+            if gd["year"]
+            else f"{day} {month}"
+        )
+
+    @classmethod
+    def timespan(cls, seconds: str) -> str:
+        """Voicify a span of time, specified in seconds."""
+        # TODO: Replace time_period_desc in queries/util/__init__.py
+        raise NotImplementedError()
+
+    @classmethod
+    def year(cls, txt: str, *, after_christ: Optional[str] = None):
+        """Voicify a year."""
+        ac = after_christ is not None and after_christ == "True"
+        return year_to_text(txt, after_christ=ac)
+
+    @classmethod
+    def years(cls, txt: str, *, after_christ: Optional[str] = None):
+        """Voicify text containing multiple years."""
+        ac = after_christ is not None and after_christ == "True"
+        return years_to_text(txt, after_christ=ac)
+
+    # Pronounciation of character names in Icelandic
+    _CHAR_PRONUNCIATION = {
+        "a": "a",
+        "á": "á",
+        "b": "bé",
+        "c": "sé",
+        "d": "dé",
+        "ð": "eð",
+        "e": "e",
+        "é": "é",
+        "f": "eff",
+        "g": "gé",
+        "h": "há",
+        "i": "i",
+        "í": "í",
+        "j": "joð",
+        "k": "ká",
+        "l": "ell",
+        "m": "emm",
+        "n": "enn",
+        "o": "o",
+        "ó": "ó",
+        "p": "pé",
+        "q": "kú",
+        "r": "err",
+        "s": "ess",
+        "t": "té",
+        "u": "u",
+        "ú": "ú",
+        "v": "vaff",
+        "w": "tvöfaltvaff",
+        "x": "ex",
+        "y": "ufsilon",
+        "ý": "ufsilon í",
+        "þ": "þoddn",
+        "æ": "æ",
+        "ö": "ö",
+        "z": "seta",
     }
-)
+
+    @classmethod
+    def spell(cls, txt: str):
+        """Spell out a sequence of characters."""
+        if not txt:
+            return ""
+        t = [cls._CHAR_PRONUNCIATION.get(c.lower(), c) if c != " " else "" for c in txt]
+        s = ", ".join(t).strip()
+        return re.sub(r"\s\s+", r" ", s)  # Shorten repeated whitespace
+
+    @classmethod
+    def abbrev(cls, txt: str):
+        """Spell out a sequence of characters."""
+        return cls.spell(txt)
+
+    _DOMAIN_PRONOUNCIATIONS = {
+        "is": "is",
+        "org": "org",
+        "net": "net",
+        "com": "komm",
+        "gmail": "gjé meil",
+        "hotmail": "hott meil",
+        "yahoo": "ja húú",
+        "outlook": "átlúkk",
+    }
+
+    @classmethod
+    def email(cls, txt: str):
+        """Voicify emails."""
+        user, domain = txt.split("@")
+        user_parts = user.split(".")
+        domain_parts = domain.split(".")
+        for i, p in enumerate(user_parts):
+            if len(p) < 3:
+                # Short parts of username get spelled out
+                user_parts[i] = cls.spell(p)
+        for i, p in enumerate(domain_parts):
+            if p in cls._DOMAIN_PRONOUNCIATIONS:
+                domain_parts[i] = cls._DOMAIN_PRONOUNCIATIONS[p]
+            elif len(p) <= 3:
+                # Spell out short, unknown domains
+                domain_parts[i] = cls.spell(p)
+        return f"{' punktur '.join(user_parts)} hjá {' punktur '.join(domain_parts)}"
+
+    @classmethod
+    def vbreak(cls, time: Optional[str] = None, strength: Optional[str] = None):
+        """Create a break in the voice/speech synthesis."""
+        if time:
+            return f'<break time="{time}" />'
+        if strength:
+            assert strength in _STRENGTHS, f"Break strength {strength} is invalid."
+            return f'<break strength="{strength}" />'
+        return f"<break />"
+
+    @classmethod
+    def paragraph(cls, txt: str):
+        return f"<p>{txt}</p>"
+
+    @classmethod
+    def sentence(cls, txt: str):
+        return f"<s>{txt}</s>"

--- a/speech/norm/num.py
+++ b/speech/norm/num.py
@@ -238,7 +238,8 @@ def number_to_text(
 def numbers_to_text(
     s: str,
     *,
-    regex: str = r"\b\d+\b",
+    regex: str = r"((?<!\d)-)?\b\d+\b",
+    # ^ matches "15" & "-15", but matches "1-5" as "1" and "5"
     case: str = "nf",
     gender: str = "hk",
     one_hundred: bool = False
@@ -325,7 +326,7 @@ def float_to_text(
 def floats_to_text(
     s: str,
     *,
-    regex: str = r"\b(\d?\d?\d\.)*\d+,\d+\b",
+    regex: str = r"(-)?\b(\d?\d?\d\.)*\d+,\d+\b",
     case: str = "nf",
     gender: str = "hk",
     comma_null: bool = False,
@@ -649,7 +650,7 @@ def number_to_ordinal(
 def numbers_to_ordinal(
     s: str,
     *,
-    regex: str = r"\b\d+\.(?=[ ,)])",
+    regex: str = r"((?<!\d\.)-)?\b\d+\.(?=[ ,)-])",
     case: str = "nf",
     gender: str = "kk",
     number: str = "et"

--- a/speech/voices/__init__.py
+++ b/speech/voices/__init__.py
@@ -56,11 +56,6 @@ def suffix_for_audiofmt(fmt: str) -> str:
     return AUDIOFMT_TO_SUFFIX.get(fmt, FALLBACK_SUFFIX)
 
 
-def strip_markup(text: str) -> str:
-    """Remove SSML markup tags from a string."""
-    return re.sub(r"<.*?>", "", text)
-
-
 def generate_data_uri(data: bytes, mime_type: str = BINARY_MIMETYPE) -> str:
     """Generate Data URI (RFC2397) from bytes."""
     b64str = b64encode(data).decode("ascii")

--- a/speech/voices/azure.py
+++ b/speech/voices/azure.py
@@ -31,11 +31,9 @@ import pathlib
 
 import azure.cognitiveservices.speech as speechsdk
 
-from speech.voices import (
-    strip_markup,
-    suffix_for_audiofmt,
-)
 from utility import RESOURCES_DIR, STATIC_DIR
+from speech.norm import DefaultNormalization, strip_markup
+from speech.voices import suffix_for_audiofmt
 
 
 NAME = "Azure Cognitive Services"
@@ -212,3 +210,34 @@ def text_to_audio_url(
     # mime_type = mimetype_for_audiofmt(audio_format)
     # data_uri = generate_data_uri(data, mime_type=mime_type)
     # return data_uri
+
+
+class Normalization(DefaultNormalization):
+    """
+    Normalization handler class,
+    specific to the Azure voice engine.
+    """
+
+    # Override some character pronounciations for
+    # normalization, custom for this speech engine
+    _CHAR_PRONUNCIATION = {
+        **DefaultNormalization._CHAR_PRONUNCIATION,
+        "b": "bjé",
+        "c": "sjé",
+        "d": "djé",
+        "ð": "eeð",
+        "e": "eeh",
+        "é": "jé",
+        "g": "gjé",
+        "i": "ii",
+        "j": "íoð",
+        "o": "úa",
+        "ó": "oú",
+        "r": "errr",
+        "t": "tjéé",
+        "ú": "úúu",
+        "ý": "ufsilon íí",
+        "þ": "þodn",
+        "æ": "æí",
+        "ö": "öö",
+    }

--- a/speech/voices/tiro.py
+++ b/speech/voices/tiro.py
@@ -28,8 +28,8 @@ import logging
 
 import requests
 
-from speech.voices import generate_data_uri, strip_markup, mimetype_for_audiofmt
-
+from speech.norm import strip_markup
+from speech.voices import generate_data_uri, mimetype_for_audiofmt
 
 NAME = "Tiro"
 VOICES = frozenset(("Alfur", "Dilja", "Bjartur", "Rosa", "Alfur_v2", "Dilja_v2"))

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -40,12 +40,13 @@ mainpath = os.path.join(basepath, "..")
 if mainpath not in sys.path:
     sys.path.insert(0, mainpath)
 
-from main import app  # noqa
+from main import app
 
-from settings import changedlocale  # noqa
-from db import SessionContext  # noqa
-from db.models import Query, QueryData, QueryLog  # noqa
-from utility import read_api_key  # noqa
+from settings import changedlocale
+from db import SessionContext
+from db.models import Query, QueryData, QueryLog
+from queries import ResponseDict
+from utility import read_api_key
 
 
 @pytest.fixture
@@ -71,7 +72,7 @@ QUERY_HISTORY_API_ENDPOINT = "/query_history.api"
 
 def qmcall(
     c: FlaskClient, qdict: Dict[str, Any], qtype: Optional[str] = None
-) -> Dict[str, Any]:
+) -> ResponseDict:
     """Use passed client object to call query API with
     query string key value pairs provided in dict arg."""
 
@@ -252,7 +253,7 @@ def test_bus(client: FlaskClient) -> None:
     json = qmcall(
         client, {"q": "hvaða stoppistöð er næst mér", "voice": True}, "NearestStop"
     )
-    assert json["answer"] == "Fiskislóð"
+    assert json["answer"] == "Fiskislóð."
     assert (
         json["voice"]
         == "Næsta stoppistöð er Fiskislóð; þangað eru þrjú hundruð og tíu metrar."
@@ -263,7 +264,80 @@ def test_bus(client: FlaskClient) -> None:
         {"q": "hvenær er von á vagni númer 17", "voice": True, "test": False},
         "ArrivalTime",
     )
-    assert json["answer"] == "Staðsetning óþekkt"  # No location info available
+    assert json["answer"] == "Staðsetning óþekkt."  # No location info available
+
+    json = qmcall(
+        client,
+        {"q": "hvenær kemur strætó númer 14 á Grandagarð", "voice": True},
+        "ArrivalTime",
+    )
+    assert json["answer"]
+    assert all(not c.isdecimal() for c in json["voice"])
+
+    json = qmcall(
+        client,
+        {"q": "hvenær kemur strætó á hlemm", "voice": True},
+        "ArrivalTime",
+    )
+    assert json["answer"].endswith("Spurðu um eina þeirra.")
+    assert all(not c.isdecimal() for c in json["voice"])
+
+    json = qmcall(
+        client,
+        {"q": "hvenær kemur strætó", "voice": True},
+        "ArrivalTime",
+    )
+    assert json["answer"]
+    assert all(not c.isdecimal() for c in json["voice"])
+
+    json = qmcall(
+        client,
+        {
+            "q": "hvaða leiðir stoppa í Bíó Paradís?",
+            "voice": True,
+            # Note: This adds a row to the QueryLog table
+            "private": False,
+        },
+        "WhichRoute",
+    )
+    assert (
+        json["answer"]
+        and "stoppar" not in json["answer"]
+        and "stoppa" in json["answer"]
+        #   (^ Multiple routes go through Bíó Paradís)
+    )
+    assert all(not c.isdecimal() for c in json["voice"])
+    # Following query relies on the query above
+    json = qmcall(
+        client,
+        {"q": "hvenær kemur strætisvagn fjórtán þangað?", "voice": True},
+        "ArrivalTime",
+    )
+    assert json["answer"] and "Bíó Paradís" in json["answer"]
+    assert (
+        all(not c.isdecimal() for c in json["voice"])
+        and "Bíó Paradís" in json["voice"]
+        and "fjórtán" in json["voice"]
+    )
+
+    json = qmcall(
+        client,
+        {"q": "Klukkan hvað stöðvar sexan á Hlemmi?", "voice": True},
+        "ArrivalTime",
+    )
+    assert json["answer"]
+    assert all(not c.isdecimal() for c in json["voice"])
+
+    json = qmcall(
+        client,
+        {
+            "q": "hvaða leiðir stoppa á Mýrarvegi Hringteig?",
+            "voice": True,
+        },
+        "WhichRoute",
+    )
+    assert "Mýrarvegi / Hringteig" in json["answer"]
+    assert all(not c.isdecimal() for c in json["voice"])
 
 
 def test_counting(client: FlaskClient) -> None:
@@ -890,78 +964,111 @@ def test_repeat(client: FlaskClient) -> None:
 def test_schedules(client: FlaskClient) -> None:
     """Schedules module"""
 
-    CURR_RE = (
-        r"^(Á {0} er verið að (sýna|spila) dagskrárliðinn .*|"
-        r"Ekkert er á dagskrá á {0} í augnablikinu\.)$"
-    )
-    NEXT_RE = (
-        r"^(Næst á dagskrá á {0} verður (sýndur|spilaður) dagskrárliðurinn .*|"
-        r"Það er ekkert á dagskrá á {0} eftir núverandi dagskrárlið\.)$"
-    )
-    ANYTIME_RE = (
-        r"^(Á {0}( klukkan \d+:\d+)?( í gær| á morgun)? "
-        r"(er verið að (spila|sýna) dagskrárliðinn|(var|verður) (spilaður|sýndur) dagskrárliðurinn) .*|"
-        r"Ekkert (er|verður|var) á dagskrá á {0} (í augnablikinu|klukkan \d?\d:\d\d( \d+\. \w+| á morgun| í gær)?)\.)$"
-    )
+    def caseless_in(a: str, b: str) -> bool:
+        """Caseless comparison"""
+        return a.casefold() in b.casefold()
+
     # RÚV tests
     json = qmcall(client, {"q": "hvað er í sjónvarpinu", "voice": True}, "Schedule")
     assert json["key"] == "RÚV - RÚV"
-    assert re.fullmatch(CURR_RE.format("RÚV"), json["answer"])
+    assert "RÚV" in json["answer"] and (
+        caseless_in("ekkert er á dagskrá", json["answer"])
+        or caseless_in("dagskrárliðinn", json["answer"])
+    )
     json = qmcall(client, {"q": "hvaða þáttur er eiginlega á rúv núna"}, "Schedule")
     assert json["key"] == "RÚV - RÚV"
-    assert re.fullmatch(CURR_RE.format("RÚV"), json["answer"])
+    assert "RÚV" in json["answer"] and (
+        caseless_in("ekkert er á dagskrá", json["answer"])
+        or caseless_in("dagskrárliðinn", json["answer"])
+    )
     json = qmcall(
         client, {"q": "hvaða þátt er verið að sýna í sjónvarpinu"}, "Schedule"
     )
     assert json["key"] == "RÚV - RÚV"
-    assert re.fullmatch(CURR_RE.format("RÚV"), json["answer"])
+    assert "RÚV" in json["answer"] and (
+        caseless_in("ekkert er á dagskrá", json["answer"])
+        or caseless_in("dagskrárliðinn", json["answer"])
+    )
 
     json = qmcall(client, {"q": "dagskrá rúv klukkan 19:00"}, "Schedule")
     assert json["key"] == "RÚV - RÚV"
-    assert re.fullmatch(ANYTIME_RE.format("RÚV"), json["answer"])
+    assert "RÚV" in json["answer"] and (
+        json["answer"].startswith("Ekkert")
+        or caseless_in("dagskrárlið", json["answer"])
+    )
     json = qmcall(client, {"q": "hvað er í sjónvarpinu í kvöld?"}, "Schedule")
     assert json["key"] == "RÚV - RÚV"
-    assert re.fullmatch(ANYTIME_RE.format("RÚV"), json["answer"])
+    assert "RÚV" in json["answer"] and (
+        json["answer"].startswith("Ekkert")
+        or caseless_in("dagskrárlið", json["answer"])
+    )
     json = qmcall(client, {"q": "hvað var í sjónvarpinu í gærkvöldi?"}, "Schedule")
     assert json["key"] == "RÚV - RÚV"
-    assert re.fullmatch(ANYTIME_RE.format("RÚV"), json["answer"])
+    assert "RÚV" in json["answer"] and (
+        json["answer"].startswith("Ekkert")
+        or caseless_in("dagskrárlið", json["answer"])
+    )
     # json = qmcall(client, {"q": "hver er sjónvarpsdagskráin í kvöld?"}, "Schedule")
     # assert json["key"] == "RÚV - RÚV"
 
     # Stöð 2 tests
     json = qmcall(client, {"q": "hvað er næsti þáttur á stöð 2"}, "Schedule")
     assert json["key"] == "Stöð 2 - Stöð 2"
-    assert re.fullmatch(NEXT_RE.format("Stöð 2"), json["answer"])
+    assert "Stöð 2" in json["answer"] and (
+        caseless_in("ekkert á dagskrá", json["answer"])
+        or caseless_in("næst á dagskrá", json["answer"])
+    )
     json = qmcall(client, {"q": "Hvaða efni er verið að spila á Stöð 2"}, "Schedule")
     assert json["key"] == "Stöð 2 - Stöð 2"
-    assert re.fullmatch(CURR_RE.format("Stöð 2"), json["answer"])
+    assert "Stöð 2" in json["answer"] and (
+        caseless_in("ekkert er á dagskrá", json["answer"])
+        or caseless_in("dagskrárliðinn", json["answer"])
+    )
 
     # Radio tests
     json = qmcall(client, {"q": "hvað er í útvarpinu?"}, "Schedule")
     assert json["key"] == "RÚV - Rás 1"
-    assert re.fullmatch(CURR_RE.format("Rás 1"), json["answer"])
+    assert "Rás 1" in json["answer"] and (
+        caseless_in("ekkert er á dagskrá", json["answer"])
+        or caseless_in("dagskrárliðinn", json["answer"])
+    )
     json = qmcall(client, {"q": "hvað er eiginlega í gangi á rás eitt?"}, "Schedule")
     assert json["key"] == "RÚV - Rás 1"
-    assert re.fullmatch(CURR_RE.format("Rás 1"), json["answer"])
+    assert "Rás 1" in json["answer"] and (
+        caseless_in("ekkert er á dagskrá", json["answer"])
+        or caseless_in("dagskrárliðinn", json["answer"])
+    )
     json = qmcall(client, {"q": "hvað er á dagskrá á rás tvö?"}, "Schedule")
     assert json["key"] == "RÚV - Rás 2"
-    assert re.fullmatch(CURR_RE.format("Rás 2"), json["answer"])
+    assert "Rás 2" in json["answer"] and (
+        caseless_in("ekkert er á dagskrá", json["answer"])
+        or caseless_in("dagskrárliðinn", json["answer"])
+    )
 
     json = qmcall(
         client, {"q": "hvað var í útvarpinu klukkan sjö í morgun"}, "Schedule"
     )
     assert json["key"] == "RÚV - Rás 1"
-    assert re.fullmatch(ANYTIME_RE.format("Rás 1"), json["answer"])
+    assert "Rás 1" in json["answer"] and (
+        json["answer"].startswith("Ekkert")
+        or caseless_in("dagskrárlið", json["answer"])
+    )
     json = qmcall(client, {"q": "hvað verður á rás 2 klukkan sjö í kvöld"}, "Schedule")
     assert json["key"] == "RÚV - Rás 2"
-    assert re.fullmatch(ANYTIME_RE.format("Rás 2"), json["answer"])
+    assert "Rás 2" in json["answer"] and (
+        json["answer"].startswith("Ekkert")
+        or caseless_in("dagskrárlið", json["answer"])
+    )
     json = qmcall(
         client,
         {"q": "hvað verður á rás 2 klukkan fjögur eftir hádegi á morgun"},
         "Schedule",
     )
     assert json["key"] == "RÚV - Rás 2"
-    assert re.fullmatch(ANYTIME_RE.format("Rás 2"), json["answer"])
+    assert "Rás 2" in json["answer"] and (
+        json["answer"].startswith("Ekkert")
+        or caseless_in("dagskrárlið", json["answer"])
+    )
     assert "16:00" in json["answer"]
     json = qmcall(
         client,
@@ -969,19 +1076,28 @@ def test_schedules(client: FlaskClient) -> None:
         "Schedule",
     )
     assert json["key"] == "RÚV - Rás 2"
-    assert re.fullmatch(ANYTIME_RE.format("Rás 2"), json["answer"])
+    assert "Rás 2" in json["answer"] and (
+        json["answer"].startswith("Ekkert")
+        or caseless_in("dagskrárlið", json["answer"])
+    )
     assert "8:00" in json["answer"]
     json = qmcall(
         client, {"q": "hvað var á rás 2 klukkan sex í gær eftir hádegi"}, "Schedule"
     )
     assert json["key"] == "RÚV - Rás 2"
-    assert re.fullmatch(ANYTIME_RE.format("Rás 2"), json["answer"])
+    assert "Rás 2" in json["answer"] and (
+        json["answer"].startswith("Ekkert")
+        or caseless_in("dagskrárlið", json["answer"])
+    )
     assert "18:00" in json["answer"]
     json = qmcall(
         client, {"q": "hvað var á rás 2 klukkan tvö fyrir hádegi í gær"}, "Schedule"
     )
     assert json["key"] == "RÚV - Rás 2"
-    assert re.fullmatch(ANYTIME_RE.format("Rás 2"), json["answer"])
+    assert "Rás 2" in json["answer"] and (
+        json["answer"].startswith("Ekkert")
+        or caseless_in("dagskrárlið", json["answer"])
+    )
     assert "2:00" in json["answer"]
 
 


### PR DESCRIPTION
Normalization of voice output to `bus.py` (Strætó) module, which also involved:
 - `bus.py` module uses NounPhrase to inflect bus stop names, shortening code. The grammar now uses `UHeilTala`.
 - Fixed `UHeilTala` nonterminal (now also correctly catches digits).
 - Improved engine-specific normalization process (now uses classes).
 - Improved regexes in `numbers_to_text/ordinal`, `floats_to_text`.
 - Implemented/Improved some normalization functions (such as the time handler and email handler).
 - Also added a bunch of tests, along with fixing the needlessly complicated `schedules.py` regex-based tests (they shouldn't fail randomly anymore).